### PR TITLE
Don't add unnecessary decimal places (.0) to properties

### DIFF
--- a/src/main/java/cz/vutbr/web/css/TermNumeric.java
+++ b/src/main/java/cz/vutbr/web/css/TermNumeric.java
@@ -7,7 +7,7 @@ package cz.vutbr.web.css;
  *
  * @param <T> Type of value stored in term
  */
-public interface TermNumeric<T> extends Term<T> {
+public interface TermNumeric<T extends Number> extends Term<T> {
 	
 	/**
 	 * These are available units in CSS

--- a/src/main/java/cz/vutbr/web/csskit/TermNumericImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/TermNumericImpl.java
@@ -2,7 +2,7 @@ package cz.vutbr.web.csskit;
 
 import cz.vutbr.web.css.TermNumeric;
 
-public class TermNumericImpl<T> extends TermImpl<T> implements TermNumeric<T> {
+public class TermNumericImpl<T extends Number> extends TermImpl<T> implements TermNumeric<T> {
 
 	protected Unit unit;
 	
@@ -25,7 +25,13 @@ public class TermNumericImpl<T> extends TermImpl<T> implements TermNumeric<T> {
     public String toString() {
 		StringBuilder sb = new StringBuilder();
 		if(operator!=null) sb.append(operator.value());
-		if(value!=null) sb.append(value);
+		if (value != null) {
+			if ((double)value.intValue() == value.doubleValue()) {
+				sb.append(value.intValue());
+			} else {
+				sb.append(value);
+			}
+		}
 		if(unit!=null) sb.append(unit.value());
 		return sb.toString();
     }


### PR DESCRIPTION
This fixes a cosmetic issue with toString() of Terms: at the moment for integer values of e.g. a length, a .0 is added.
Example: `padding: 5px` becomes `padding: 5.0px`