### PR TITLE
Don't ignore operator in TermIntegerImpl.toString()

### DIFF
--- a/src/main/java/cz/vutbr/web/csskit/TermIntegerImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/TermIntegerImpl.java
@@ -20,6 +20,8 @@ public class TermIntegerImpl extends TermLengthImpl implements TermInteger {
     @Override
     public String toString()
     {
+        if (operator != null)
+            return operator.value() + getIntValue();
         return String.valueOf(getIntValue());
     }
 


### PR DESCRIPTION
At the moment, the operator is ignored int TermIntegerImpl.toString(). This causes issues with source declarations with multiple values, e.g. `padding: 5px 0 0 0;` becomes `padding: 5.0px 000;`

This commit fixes the issue.