### PR TITLE
quick hover

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
 		<dependency>
 			<groupId>org.unbescape</groupId>
 			<artifactId>unbescape</artifactId>
-			<version>1.1.0.RELEASE</version>
+			<version>1.1.1.RELEASE</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -157,7 +157,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
     /**
      * Matches simple selector against DOM element
      * @param e Element
-     * @return <code>true</true> in case of match
+     * @return <code>true</code> in case of match
      */
     public boolean matches(Element e);
     
@@ -165,7 +165,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
      * Matches simple selector against DOM element with an additional condition
      * @param e Element
      * @param cond An additional condition to be applied
-     * @return <code>true</true> in case of match
+     * @return <code>true</code> in case of match
      */
     public boolean matches(Element e, MatchCondition cond);
     

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -143,6 +143,12 @@ public interface Selector extends Rule<Selector.SelectorPart> {
     public PseudoDeclaration getPseudoElement();
     
     /**
+     * Checks where the specified pseudo declaration is in this selector
+     * @return <code>true</code> if the selector has the specified pseudo declaration
+     */
+    public boolean hasPseudoDeclaration(final PseudoDeclaration pd);
+
+    /**
      * Modifies specificity according to CSS standard
      * @param spec Specificity to be modified
      */

--- a/src/main/java/cz/vutbr/web/css/TermNumeric.java
+++ b/src/main/java/cz/vutbr/web/css/TermNumeric.java
@@ -2,7 +2,7 @@ package cz.vutbr.web.css;
 
 /**
  * Holds value of numeric type. This could be integer or float
- * according to <T>.
+ * according to &lt;T&gt;.
  * @author kapy
  *
  * @param <T> Type of value stored in term

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -82,18 +82,16 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
     }
     
     public PseudoDeclaration getPseudoElement() {
-        PseudoDeclaration ret = null;
         for(SelectorPart item : list) {
             if(item instanceof PseudoPage)
             {
-                ret = ((PseudoPage)item).getDeclaration();
-                if (ret.isPseudoElement())
-                    break; //pseudo-elements may only be appended after the last simple selector of the selector
-                else
-                    ret = null; //not interested in pseudo-classes
+                final PseudoDeclaration ret = ((PseudoPage)item).getDeclaration();
+                if (ret.isPseudoElement()) {
+                    return ret; //pseudo-elements may only be appended after the last simple selector of the selector
+                }
             }
         }
-        return ret;
+        return null;
     }
     
     public boolean hasPseudoDeclaration(final PseudoDeclaration pd) {

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -96,6 +96,19 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         return ret;
     }
     
+    public boolean hasPseudoDeclaration(final PseudoDeclaration pd) {
+        for(SelectorPart item : list) {
+            if(item instanceof PseudoPage)
+            {
+                final PseudoDeclaration ret = ((PseudoPage)item).getDeclaration();
+                if (ret == pd) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    	
     public boolean matches(Element e) {
     	
 		// check other items of simple selector

--- a/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
+++ b/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
@@ -1,0 +1,487 @@
+package cz.vutbr.web.domassign;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import cz.vutbr.web.css.CSSFactory;
+import cz.vutbr.web.css.CombinedSelector;
+import cz.vutbr.web.css.Declaration;
+import cz.vutbr.web.css.MatchCondition;
+import cz.vutbr.web.css.MediaQuery;
+import cz.vutbr.web.css.MediaSpec;
+import cz.vutbr.web.css.NodeData;
+import cz.vutbr.web.css.Rule;
+import cz.vutbr.web.css.RuleMedia;
+import cz.vutbr.web.css.RuleSet;
+import cz.vutbr.web.css.Selector;
+import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.StyleSheet;
+import cz.vutbr.web.csskit.ElementUtil;
+import cz.vutbr.web.domassign.Analyzer.Holder;
+import cz.vutbr.web.domassign.Analyzer.HolderItem;
+import cz.vutbr.web.domassign.Analyzer.HolderSelector;
+import cz.vutbr.web.domassign.Analyzer.OrderedRule;
+
+/**
+ * A pure (state-less) Analyser.
+ * 
+ * Can be used by clients that need more control over what computation is cached.
+ *
+ */
+public final class AnalyzerUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(AnalyzerUtil.class);
+
+    /**
+     * Returns all applicable rules for an element
+     * 
+     * @param sheets
+     * @param element
+     * @param mediaspec
+     * @return
+     */
+    public static OrderedRule[] getApplicableRules(final List<StyleSheet> sheets, final Element element, final MediaSpec mediaspec) {
+	    final Holder rules = new Holder();
+	    AnalyzerUtil.classifyAllSheets(sheets, rules, mediaspec);
+	    return getApplicableRules(element, rules);
+    }
+
+    public static NodeData getElementStyle(Element el, PseudoDeclaration pseudo, MatchCondition matchCond, OrderedRule[] applicableRules)
+    {
+    	return makeNodeData(computeDeclarations(el, pseudo, applicableRules, matchCond));
+    }
+
+	private static OrderedRule[] getApplicableRules(final Element e, final Holder holder)
+	{
+        // create set of possible candidates applicable to given element
+        // set is automatically filtered to not contain duplicates
+        final Set<OrderedRule> candidates = new HashSet<OrderedRule>();
+
+        // match element classes
+        for (final String cname : ElementUtil.elementClasses(e)) {
+            // holder contains rule with given class
+            final List<OrderedRule> classRules = holder.get(HolderItem.CLASS, cname.toLowerCase());
+            if (classRules != null)
+                candidates.addAll(classRules);
+        }
+        log.trace("After CLASSes {} total candidates.", candidates.size());
+
+        // match IDs
+        final String id = ElementUtil.elementID(e);
+        if (id != null && id.length() != 0) {
+            final List<OrderedRule> idRules = holder.get(HolderItem.ID, id.toLowerCase());
+            if (idRules != null)
+                candidates.addAll(idRules);
+        }
+        log.trace("After IDs {} total candidates.", candidates.size());
+        
+        // match elements
+        final String name = ElementUtil.elementName(e);
+        if (name != null) {
+            final List<OrderedRule> nameRules = holder.get(HolderItem.ELEMENT, name.toLowerCase());
+            if (nameRules != null)
+                candidates.addAll(nameRules);
+        }
+        log.trace("After ELEMENTs {} total candidates.", candidates.size());
+
+        // others
+        candidates.addAll(holder.get(HolderItem.OTHER, null));
+
+        final int totalCandidates = candidates.size();
+        log.debug("Totally {} candidates.", totalCandidates);
+
+        // transform to array to speed up traversal
+        // and sort rules in order as they were found in CSS definition
+        final OrderedRule[] clist = (OrderedRule[]) candidates.toArray(new OrderedRule[totalCandidates]);
+        Arrays.sort(clist);
+
+        log.trace("With values: {}", Arrays.toString(clist));
+
+        return clist;
+	}
+
+	static NodeData makeNodeData(final List<Declaration> decls)
+	{
+		final NodeData main = CSSFactory.createNodeData();
+        for (final Declaration d : decls)
+            main.push(d);
+        
+        return main;
+	}
+    
+	/**
+	 * Classifies the rules in all the style sheets.
+	 * @param mediaspec The specification of the media for evaluating the media queries.
+	 */
+	static void classifyAllSheets(final List<StyleSheet> sheets, final Holder rules, final MediaSpec mediaspec)
+	{
+	    for (final StyleSheet sheet : sheets)
+	        classifyRules(sheet, mediaspec, rules);
+	}
+	
+	static boolean elementSelectorMatches(final Selector s, final Element e, final MatchCondition matchCond) {
+		return matchCond == null ? s.matches(e) : s.matches(e, matchCond);
+	}
+
+    private static boolean nodeSelectorMatches(final Selector s, final Node n, final MatchCondition matchCond) {
+        if (n.getNodeType() == Node.ELEMENT_NODE) {
+            final Element e = (Element) n;
+            return matchCond == null ? s.matches(e) : s.matches(e, matchCond);
+        } else {
+            return false;
+        }
+    }
+    
+	static List<Declaration> computeDeclarations(final Element e, final PseudoDeclaration pseudo, final OrderedRule[] clist, final MatchCondition matchCond) {
+		// resulting list of declaration for this element with no pseudo-selectors (main list)(local cache)
+        final List<Declaration> eldecl = new ArrayList<Declaration>();
+        
+        // for all candidates
+        for (final OrderedRule orule : clist) {
+            
+            final RuleSet rule = orule.getRule();
+            final StyleSheet sheet = rule.getStyleSheet();
+            final StyleSheet.Origin origin = (sheet == null) ? StyleSheet.Origin.AGENT : sheet.getOrigin();
+            
+            // for all selectors inside
+            for (final CombinedSelector s : rule.getSelectors()) {
+                
+                if (!AnalyzerUtil.matchSelector(s, e, matchCond)) {
+                    log.trace("CombinedSelector \"{}\" NOT matched!", s);
+                    continue;
+                }
+
+                log.trace("CombinedSelector \"{}\" matched", s);
+                
+                final PseudoDeclaration psel = s.getPseudoElement();
+                final CombinedSelector.Specificity spec = s.computeSpecificity();
+                if (psel == pseudo)
+                {
+                    // add to the resulting list
+                    for (final Declaration d : rule)
+                        eldecl.add(new AssignedDeclaration(d, spec, origin));
+                }
+            }
+        }
+
+        // sort declarations
+        Collections.sort(eldecl); //sort the main list
+        log.debug("Sorted {} declarations.", eldecl.size());
+        log.trace("With values: {}", eldecl);
+        
+        return eldecl;
+	}
+    
+    public static boolean hasPseudoSelector(final OrderedRule[] rules, final Element e, final MatchCondition matchCond, PseudoDeclaration pd)
+    {
+		for (final OrderedRule rule : rules) {
+			for (final CombinedSelector cs : rule.getRule().getSelectors()) {
+				final Selector lastSelector = cs.get(cs.size() - 1);
+				if (lastSelector.hasPseudoDeclaration(pd)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+    public static boolean hasPseudoSelectorForAncestor(final OrderedRule[] rules, final Element e, final Element targetAncestor, final MatchCondition matchCond, PseudoDeclaration pd)
+    {
+		for (final OrderedRule rule : rules) {
+			for (final CombinedSelector cs : rule.getRule().getSelectors()) {
+				if (hasPseudoSelectorForAncestor(cs, e, targetAncestor, matchCond, pd)) {
+					return true;
+				}
+			}
+		}
+		return false;
+    }
+
+    private static boolean hasPseudoSelectorForAncestor(final CombinedSelector sel, final Element e, final Element targetAncestor, final MatchCondition matchCond, PseudoDeclaration pd)
+    {
+        boolean retval = false;
+        Selector.Combinator combinator = null;
+        Element current = e;
+        // traverse simple selector backwards
+        for (int i = sel.size() - 1; i >= 0; i--) {
+            // last simple selector
+            final Selector s = sel.get(i);
+
+            // decide according to combinator anti-pattern
+            if (combinator == null) {
+                retval = elementSelectorMatches(s, current, matchCond);
+            } else if (combinator == Selector.Combinator.ADJACENT) {
+                Node adjacent = current;
+                do {
+                    adjacent = adjacent.getPreviousSibling();
+                } while (adjacent != null && adjacent.getNodeType() != Node.ELEMENT_NODE);
+                retval = false;
+                if (adjacent != null && adjacent.getNodeType() == Node.ELEMENT_NODE)
+                {
+                    current = (Element) adjacent; 
+                    retval = elementSelectorMatches(s, current, matchCond);
+                }
+            } else if (combinator == Selector.Combinator.PRECEDING) {
+                Node preceding = current.getPreviousSibling();
+                retval = false;
+                do
+                {
+                    if (preceding != null)
+                    {
+                        if (nodeSelectorMatches(s, preceding, matchCond))
+                        {
+                            current = (Element) preceding;
+                            retval = true;
+                        }
+                        else
+                            preceding = preceding.getPreviousSibling();
+                    }
+                } while (!retval && preceding != null);
+            } else if (combinator == Selector.Combinator.DESCENDANT) {
+                Node ancestor = current.getParentNode();
+                retval = false;
+                do
+                {
+                    if (ancestor != null)
+                    {
+                        if (nodeSelectorMatches(s, ancestor, matchCond))
+                        {
+                            current = (Element) ancestor;
+                            retval = true;
+                        }
+                        else
+                            ancestor = ancestor.getParentNode();
+                    }
+                } while (!retval && ancestor != null);
+            } else if (combinator == Selector.Combinator.CHILD) {
+                final Node parent = current.getParentNode();
+                retval = false;
+                if (parent != null && parent.getNodeType() == Node.ELEMENT_NODE)
+                {
+                    current = (Element) parent;
+                    retval = elementSelectorMatches(s, current, matchCond);
+                }
+            }
+
+            // set combinator for next loop
+            combinator = s.getCombinator();
+
+            // leave loop if not matched
+            if (!retval) {
+                break;
+            } else if (current == targetAncestor) {
+                return s.hasPseudoDeclaration(pd);
+            }
+        }
+        return false;
+    }
+
+    protected static boolean matchSelector(final CombinedSelector sel, final Element e, final MatchCondition matchCond)
+    {
+        boolean retval = false;
+        Selector.Combinator combinator = null;
+        Element current = e;
+        // traverse simple selector backwards
+        for (int i = sel.size() - 1; i >= 0; i--) {
+            // last simple selector
+            final Selector s = sel.get(i);
+            log.trace("Iterating loop with selector {}, combinator {}",
+                    s, combinator);
+
+            // decide according to combinator anti-pattern
+            if (combinator == null) {
+                retval = elementSelectorMatches(s, current, matchCond);
+            } else if (combinator == Selector.Combinator.ADJACENT) {
+                Node adjacent = current;
+                do {
+                    adjacent = adjacent.getPreviousSibling();
+                } while (adjacent != null && adjacent.getNodeType() != Node.ELEMENT_NODE);
+                retval = false;
+                if (adjacent != null && adjacent.getNodeType() == Node.ELEMENT_NODE)
+                {
+                    current = (Element) adjacent; 
+                    retval = elementSelectorMatches(s, current, matchCond);
+                }
+            } else if (combinator == Selector.Combinator.PRECEDING) {
+                Node preceding = current.getPreviousSibling();
+                retval = false;
+                do
+                {
+                    if (preceding != null)
+                    {
+                        if (nodeSelectorMatches(s, preceding, matchCond))
+                        {
+                            current = (Element) preceding;
+                            retval = true;
+                        }
+                        else
+                            preceding = preceding.getPreviousSibling();
+                    }
+                } while (!retval && preceding != null);
+            } else if (combinator == Selector.Combinator.DESCENDANT) {
+                Node ancestor = current.getParentNode();
+                retval = false;
+                do
+                {
+                    if (ancestor != null)
+                    {
+                        if (nodeSelectorMatches(s, ancestor, matchCond))
+                        {
+                            current = (Element) ancestor;
+                            retval = true;
+                        }
+                        else
+                            ancestor = ancestor.getParentNode();
+                    }
+                } while (!retval && ancestor != null);
+            } else if (combinator == Selector.Combinator.CHILD) {
+                final Node parent = current.getParentNode();
+                retval = false;
+                if (parent != null && parent.getNodeType() == Node.ELEMENT_NODE)
+                {
+                    current = (Element) parent;
+                    retval = elementSelectorMatches(s, current, matchCond);
+                }
+            }
+
+            // set combinator for next loop
+            combinator = s.getCombinator();
+
+            // leave loop if not matched
+            if (!retval)
+                break;
+        }
+        return retval;
+    }
+    
+	/**
+	 * Classify CSS rule according its selector for to be of specified item(s)
+	 * 
+	 * @param selector
+	 *            CombinedSelector of rules
+	 * @return List of HolderSelectors to which selectors conforms
+	 */
+	private static List<HolderSelector> classifySelector(final CombinedSelector selector) {
+
+		final List<HolderSelector> hs = new ArrayList<HolderSelector>();
+
+		try {
+			// last simple selector decided about all selector
+			final Selector last = selector.getLastSelector();
+
+			// is element or other (wildcard)
+			final String element = last.getElementName();
+			if (element != null) {
+				// wildcard
+				if (Selector.ElementName.WILDCARD.equals(element))
+					hs.add(new HolderSelector(HolderItem.OTHER, null));
+				// element
+				else
+					hs.add(new HolderSelector(HolderItem.ELEMENT, element
+							.toLowerCase()));
+			}
+
+			// is class name
+			final String className = last.getClassName();
+			if (className != null)
+				hs.add(new HolderSelector(HolderItem.CLASS, className
+						.toLowerCase()));
+
+			// is id
+			final String id = last.getIDName();
+			if (id != null)
+				hs.add(new HolderSelector(HolderItem.ID, id.toLowerCase()));
+
+			// is in others
+			if (hs.size() == 0)
+				hs.add(new HolderSelector(HolderItem.OTHER, null));
+
+			return hs;
+
+		} catch (final UnsupportedOperationException e) {
+			log
+					.error("CombinedSelector does not include any selector, this should not happen!");
+			return Collections.emptyList();
+		}
+	}
+
+	private static class Counter {
+		private int count = 0;
+		public int getAndIncrement() {
+			return count++;
+		}
+	}
+
+	private static void insertClassified(final Holder holder, final List<HolderSelector> hs, final RuleSet value, final Counter orderCounter) {
+		for (final HolderSelector h : hs)
+			holder.insert(h.item, h.key, new OrderedRule(value, orderCounter.getAndIncrement()));
+	}
+
+	/**
+	 * Divides rules in sheet into different categories to be easily and more
+	 * quickly parsed afterward
+	 * 
+	 * @param sheet The style sheet to be classified
+     * @param mediaspec The specification of the media for evaluating the media queries.
+	 */
+	private static void classifyRules(final StyleSheet sheet, final MediaSpec mediaspec, final Holder rules) {
+		final Counter orderCounter = new Counter();
+
+		for (final Rule<?> rule : sheet) {
+			// this rule conforms to all media
+			if (rule instanceof RuleSet) {
+				final RuleSet ruleset = (RuleSet) rule;
+				for (final CombinedSelector s : ruleset.getSelectors()) {
+					insertClassified(rules, classifySelector(s), ruleset, orderCounter);
+				}
+			}
+			// this rule conforms to different media
+			else if (rule instanceof RuleMedia) {
+				final RuleMedia rulemedia = (RuleMedia) rule;
+
+				boolean mediaValid = false;
+                if(rulemedia.getMediaQueries()==null || rulemedia.getMediaQueries().isEmpty()) {
+                    //no media queries actually
+                    mediaValid = mediaspec.matchesEmpty();
+                } else {
+                    //find a matching query
+    				for (final MediaQuery media : rulemedia.getMediaQueries()) {
+                        if (mediaspec.matches(media)) {
+                            mediaValid = true;
+                            break;
+                        }
+    				}
+                }
+				
+                if (mediaValid)
+                {
+    				// for all rules in media set
+    				for (final RuleSet ruleset : rulemedia) {
+    					// for all selectors in there
+    					for (final CombinedSelector s : ruleset.getSelectors()) {
+   							insertClassified(rules, classifySelector(s), ruleset, orderCounter);
+    					}
+    				}
+                }
+			}
+		}
+
+		// logging
+		if (log.isDebugEnabled()) {
+			log.debug("For media \"{}\" we have {} rules", mediaspec, rules.contentCount());
+			if(log.isTraceEnabled()) {
+				log.trace("Detailed view: \n{}", rules);
+			}
+		}
+	}
+
+}

--- a/src/main/java/cz/vutbr/web/domassign/DeclarationTransformer.java
+++ b/src/main/java/cz/vutbr/web/domassign/DeclarationTransformer.java
@@ -266,7 +266,7 @@ public class DeclarationTransformer {
 	 *            used
 	 * @param term
 	 *            TermIdent to be transfered to property
-	 * @return CSSProperty of type <T> or <code>null</code>
+	 * @return CSSProperty of type &lt;T&gt; or <code>null</code>
 	 */
 	public <T extends CSSProperty> T genericPropertyRaw(Class<T> type,
 			Set<T> intersection, TermIdent term) {
@@ -287,7 +287,7 @@ public class DeclarationTransformer {
 	 * properties map under key property
 	 * 
 	 * @param <T>
-	 *            Enum & CSSProperty limitation
+	 *            Enum &amp; CSSProperty limitation
 	 * @param type
 	 *            Type of enum which instance is retrieved
 	 * @param term

--- a/src/main/java/cz/vutbr/web/domassign/DirectAnalyzer.java
+++ b/src/main/java/cz/vutbr/web/domassign/DirectAnalyzer.java
@@ -5,28 +5,16 @@
  */
 package cz.vutbr.web.domassign;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
-import cz.vutbr.web.css.CSSFactory;
-import cz.vutbr.web.css.CombinedSelector;
-import cz.vutbr.web.css.Declaration;
-import cz.vutbr.web.css.MatchCondition;
 import cz.vutbr.web.css.MediaSpec;
 import cz.vutbr.web.css.NodeData;
-import cz.vutbr.web.css.RuleSet;
-import cz.vutbr.web.css.Selector;
 import cz.vutbr.web.css.Selector.PseudoDeclaration;
 import cz.vutbr.web.css.StyleSheet;
-import cz.vutbr.web.csskit.ElementUtil;
 
 /**
  * A simple ananalyzer that computes a style for the individual DOM nodes with no mapping and caching.
@@ -67,18 +55,10 @@ public class DirectAnalyzer extends Analyzer
      */
     public NodeData getElementStyle(Element el, PseudoDeclaration pseudo, MediaSpec media)
     {
-        if (rules == null)
-            classifyAllSheets(media);
-        
-        List<Declaration> decls = getDeclarationsForElement(el, pseudo, rules);
-        
-        NodeData main = CSSFactory.createNodeData();
-        for (Declaration d : decls)
-            main.push(d);
-        
-        return main;
+        final OrderedRule[] applicableRules = AnalyzerUtil.getApplicableRules(sheets, el, media);
+        return AnalyzerUtil.getElementStyle(el, pseudo, getMatchCondition(), applicableRules);
     }
-    
+
     /**
      * Computes the style of an element with an eventual pseudo element for the given media.
      * @param el The DOM element.
@@ -92,181 +72,5 @@ public class DirectAnalyzer extends Analyzer
     }
     
     //==========================================================================================
-    
-    protected List<Declaration> getDeclarationsForElement(Element e, PseudoDeclaration pseudo, Holder holder) 
-    {
-        if(log.isDebugEnabled()) {
-            log.debug("Traversal of {} {}.", e.getNodeName(), e.getNodeValue());
-        }
 
-        // create set of possible candidates applicable to given element
-        // set is automatically filtered to not contain duplicates
-        Set<OrderedRule> candidates = new HashSet<OrderedRule>();
-
-        // match element classes
-        for (String cname : ElementUtil.elementClasses(e)) {
-            // holder contains rule with given class
-            List<OrderedRule> rules = holder.get(HolderItem.CLASS, cname.toLowerCase());
-            if (rules != null)
-                candidates.addAll(rules);
-        }
-        log.trace("After CLASSes {} total candidates.", candidates.size());
-
-        // match IDs
-        String id = ElementUtil.elementID(e);
-        if (id != null && id.length() != 0) {
-            List<OrderedRule> rules = holder.get(HolderItem.ID, id.toLowerCase());
-            if (rules != null)
-                candidates.addAll(rules);
-        }
-        log.trace("After IDs {} total candidates.", candidates.size());
-        
-        // match elements
-        String name = ElementUtil.elementName(e);
-        if (name != null) {
-            List<OrderedRule> rules = holder.get(HolderItem.ELEMENT, name.toLowerCase());
-            if (rules != null)
-                candidates.addAll(rules);
-        }
-        log.trace("After ELEMENTs {} total candidates.", candidates.size());
-
-        // others
-        candidates.addAll(holder.get(HolderItem.OTHER, null));
-
-        // transform to list to speed up traversal
-        // and sort rules in order as they were found in CSS definition
-        List<OrderedRule> clist = new ArrayList<OrderedRule>(candidates);
-        Collections.sort(clist);
-        
-        log.debug("Totally {} candidates.", candidates.size());
-        log.trace("With values: {}", clist);
-
-        // resulting list of declaration for this element with no pseudo-selectors (main list)(local cache)
-        List<Declaration> eldecl = new ArrayList<Declaration>();
-        
-        // for all candidates
-        for (OrderedRule orule : clist) {
-            
-            final RuleSet rule = orule.getRule();
-            StyleSheet sheet = rule.getStyleSheet();
-            StyleSheet.Origin origin = (sheet == null) ? StyleSheet.Origin.AGENT : sheet.getOrigin();
-            
-            // for all selectors inside
-            for (CombinedSelector s : rule.getSelectors()) {
-                
-                if (!matchSelector(s, e)) {
-                    log.trace("CombinedSelector \"{}\" NOT matched!", s);
-                    continue;
-                }
-
-                log.trace("CombinedSelector \"{}\" matched", s);
-                
-                PseudoDeclaration psel = s.getPseudoElement();
-                CombinedSelector.Specificity spec = s.computeSpecificity();
-                if (psel == pseudo)
-                {
-                    // add to the resulting list
-                    for (Declaration d : rule)
-                        eldecl.add(new AssignedDeclaration(d, spec, origin));
-                }
-            }
-        }
-
-        // sort declarations
-        Collections.sort(eldecl); //sort the main list
-        log.debug("Sorted {} declarations.", eldecl.size());
-        log.trace("With values: {}", eldecl);
-        
-        return eldecl;
-    }
-
-    private boolean nodeSelectorMatches(final Selector s, final Node n) {
-        if (n.getNodeType() == Node.ELEMENT_NODE) {
-            final Element e = (Element) n;
-            final MatchCondition matchCond = this.getMatchCondition();
-            return matchCond == null ? s.matches(e) : s.matches(e, matchCond);
-        } else {
-            return false;
-        }
-    }
-    
-    protected boolean matchSelector(CombinedSelector sel, Element e)
-    {
-        boolean retval = false;
-        Selector.Combinator combinator = null;
-        Element current = e;
-        // traverse simple selector backwards
-        for (int i = sel.size() - 1; i >= 0; i--) {
-            // last simple selector
-            Selector s = sel.get(i);
-            log.trace("Iterating loop with selector {}, combinator {}",
-                    s, combinator);
-
-            // decide according to combinator anti-pattern
-            if (combinator == null) {
-                retval = this.elementSelectorMatches(s, current);
-            } else if (combinator == Selector.Combinator.ADJACENT) {
-                Node adjacent = current;
-                do {
-                    adjacent = adjacent.getPreviousSibling();
-                } while (adjacent != null && adjacent.getNodeType() != Node.ELEMENT_NODE);
-                retval = false;
-                if (adjacent != null && adjacent.getNodeType() == Node.ELEMENT_NODE)
-                {
-                    current = (Element) adjacent; 
-                    retval = this.elementSelectorMatches(s, current);
-                }
-            } else if (combinator == Selector.Combinator.PRECEDING) {
-                Node preceding = current.getPreviousSibling();
-                retval = false;
-                do
-                {
-                    if (preceding != null)
-                    {
-                        if (this.nodeSelectorMatches(s, preceding))
-                        {
-                            current = (Element) preceding;
-                            retval = true;
-                        }
-                        else
-                            preceding = preceding.getPreviousSibling();
-                    }
-                } while (!retval && preceding != null);
-            } else if (combinator == Selector.Combinator.DESCENDANT) {
-                Node ancestor = current.getParentNode();
-                retval = false;
-                do
-                {
-                    if (ancestor != null)
-                    {
-                        if (this.nodeSelectorMatches(s, ancestor))
-                        {
-                            current = (Element) ancestor;
-                            retval = true;
-                        }
-                        else
-                            ancestor = ancestor.getParentNode();
-                    }
-                } while (!retval && ancestor != null);
-            } else if (combinator == Selector.Combinator.CHILD) {
-                Node parent = current.getParentNode();
-                retval = false;
-                if (parent != null && parent.getNodeType() == Node.ELEMENT_NODE)
-                {
-                    current = (Element) parent;
-                    retval = this.elementSelectorMatches(s, current);
-                }
-            }
-
-            // set combinator for next loop
-            combinator = s.getCombinator();
-
-            // leave loop if not matched
-            if (!retval)
-                break;
-        }
-        return retval;
-    }
-    
-    
 }

--- a/src/main/java/cz/vutbr/web/domassign/Variator.java
+++ b/src/main/java/cz/vutbr/web/domassign/Variator.java
@@ -100,9 +100,9 @@ public abstract class Variator {
 	 * <li><code>margin-right: inherit</code></li>
 	 * <li><code>margin-bottom: inherit</code></li>
 	 * <li><code>margin-left: inherit</code></li>
-	 * <ul>
+	 * </ul>
 	 * 
-	 * <br/> <code>margin: 0px inherit</code> is invalid value.
+	 * <code>margin: 0px inherit</code> is invalid value.
 	 * 
 	 * @param variant
 	 *            Number of variant or identifier of all variants
@@ -167,22 +167,22 @@ public abstract class Variator {
 	 * Check if variant, which was passed is able to be located in place where it was 
 	 * found.
 	 * 
-	 * Example:<br/>
+	 * Example:
 	 * We have declaration:
 	 * <code>font: 12px/14px sans-serif</code>
-	 * Then according to grammar:<br/>
+	 * Then according to grammar:
 	 * <pre>
 	 * 	[ 
-	 * 		[ <'font-style'> || <'font-variant'> || <'font-weight'> ]? 
-	 * 		<'font-size'> 
-	 * 		[ / <'line-height'> ]? 
-	 * 		<'font-family'> 
+	 * 		[ &lt;'font-style'&gt; || &lt;'font-variant'&gt; || &lt;'font-weight'&gt; ]? 
+	 * 		&lt;'font-size'&gt; 
+	 * 		[ / &lt;'line-height'&gt; ]? 
+	 * 		&lt;'font-family'&gt; 
 	 *  ] 
 	 *  | caption | icon | menu | message-box | 
 	 *  small-caption | status-bar | inherit
 	 * </pre> 
 	 * <ol>
-	 * <li><code>12px</code> is assigned to </i>font-size</i></li>
+	 * <li><code>12px</code> is assigned to <i>font-size</i></li>
 	 * <li><code>14px</code> is checked to have SLASH operator before 
 	 * and check to whether <i>font-size</i> was defined before it</li>
 	 * <li><code>sans-serif</code> is tested to have at least 


### PR DESCRIPTION
## For #17 


### API to get selectors that match a pseudo clause
I have created a new class called `AnalyserUtil` which is designed to be pure (state-less) class. The functions in this class are all declared `static`.  There are only 4 public functions: getApplicableRules, getElementStyle, hasPseudoSelctor, hasPseudoSelectorForAncestor. The idea is that clients can use these functions efficiently, without necessarily storing / recreating an Analyser instance. They can choose to cache the intermediate results (such as the result of getApplicableRules).

This has been done without modifying the existing APIs and verifying that all unit tests pass. I have also tested everything in gngr.

### Minor cleanup
* Fixed javadoc errors
* Simplified the function: `SelectorImpl.getPseudoElement`
* Updated version of unbescape to latest, 1.1.1