### PR TITLE
handle attribute selectors with back slashes

### DIFF
--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -876,7 +876,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 		}
 		
     	public ElementAttribute setValue(String value) {
-            this.value = value == null ? value : value.replaceAll("\\\\", "");
+            this.value = value == null ? null : value.replace("\\", "");
             return this;
     	}
 		

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -876,8 +876,8 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 		}
 		
     	public ElementAttribute setValue(String value) {
-    		this.value = value;
-    		return this;
+            this.value = value == null ? value : value.replaceAll("\\\\", "");
+            return this;
     	}
 		
 		@Override

--- a/src/test/java/test/DOMSource.java
+++ b/src/test/java/test/DOMSource.java
@@ -20,6 +20,7 @@
 
 package test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -39,6 +40,11 @@ public class DOMSource
     private InputStream is;
     private Document doc;
     private String charset;
+
+    public DOMSource(final String input)
+    {
+        this.is = new ByteArrayInputStream(input.getBytes());
+    }
 
     public DOMSource(InputStream is)
     {

--- a/src/test/java/test/SelectorTest.java
+++ b/src/test/java/test/SelectorTest.java
@@ -1,7 +1,8 @@
 package test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Date;
@@ -11,14 +12,18 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
+import cz.vutbr.web.css.CSSException;
 import cz.vutbr.web.css.CSSFactory;
 import cz.vutbr.web.css.CombinedSelector;
 import cz.vutbr.web.css.RuleFactory;
 import cz.vutbr.web.css.RuleSet;
 import cz.vutbr.web.css.Selector;
 import cz.vutbr.web.css.StyleSheet;
-import cz.vutbr.web.css.CSSException;
 import cz.vutbr.web.css.Term;
 import cz.vutbr.web.css.TermFactory;
 import cz.vutbr.web.css.TermNumeric;
@@ -230,6 +235,25 @@ public class SelectorTest {
 		assertEquals("Rule contains one declaration { text-align: right }",
 				DeclarationsUtil.appendDeclaration(null, "text-align", tf
 						.createIdent("right")), rule.asList());
+	}
+
+	@Test
+	public void testTypeAttrib() throws CSSException, IOException, SAXException {
+	    final String TEST_TYPE_ATTRIB_ESCAPED = "script[type=text\\/plain] { text-align: right}";
+
+		final StyleSheet ss = CSSFactory.parseString(TEST_TYPE_ATTRIB_ESCAPED, null);
+		assertEquals("One rule is set", 1, ss.size());
+
+		final RuleSet rule = (RuleSet) ss.get(0);
+		assertEquals("One combined selector", rule.getSelectors().length, 1);
+		final CombinedSelector cs = rule.getSelectors()[0];
+		assertEquals("One selector", cs.size(), 1);
+
+		final Selector s = cs.get(0);
+        DOMSource ds = new DOMSource("<script type='text/plain'>Hello world</script>");
+        Document doc = ds.parse();
+        final Element scriptElement = (Element) doc.getElementsByTagName("script").item(0);
+		assertTrue("selector matches", s.matches(scriptElement));
 	}
 
 	@Test

--- a/src/test/java/test/SelectorTest.java
+++ b/src/test/java/test/SelectorTest.java
@@ -239,7 +239,7 @@ public class SelectorTest {
 
 	@Test
 	public void testTypeAttrib() throws CSSException, IOException, SAXException {
-	    final String TEST_TYPE_ATTRIB_ESCAPED = "script[type=text\\/plain] { text-align: right}";
+		final String TEST_TYPE_ATTRIB_ESCAPED = "script[type=text\\/plain] { text-align: right}";
 
 		final StyleSheet ss = CSSFactory.parseString(TEST_TYPE_ATTRIB_ESCAPED, null);
 		assertEquals("One rule is set", 1, ss.size());
@@ -250,9 +250,9 @@ public class SelectorTest {
 		assertEquals("One selector", cs.size(), 1);
 
 		final Selector s = cs.get(0);
-        DOMSource ds = new DOMSource("<script type='text/plain'>Hello world</script>");
-        Document doc = ds.parse();
-        final Element scriptElement = (Element) doc.getElementsByTagName("script").item(0);
+		DOMSource ds = new DOMSource("<script type='text/plain'>Hello world</script>");
+		Document doc = ds.parse();
+		final Element scriptElement = (Element) doc.getElementsByTagName("script").item(0);
 		assertTrue("selector matches", s.matches(scriptElement));
 	}
 


### PR DESCRIPTION
Attribute matching was failing when the selector contained backslash.

The unit test will hopefully indicate the context of this fix.


PS. Thanks for fixing the other issues today!