### PR TITLE
Modularise the AnalyzerUtil class to allow optimisations in clients

### DIFF
--- a/src/main/java/cz/vutbr/web/domassign/Analyzer.java
+++ b/src/main/java/cz/vutbr/web/domassign/Analyzer.java
@@ -465,7 +465,7 @@ public class Analyzer {
 	 * @author kapy
 	 * 
 	 */
-	protected static class Holder {
+	public static class Holder {
 
 		/** HolderItem.* except OTHER are stored there */
 		private List<Map<String, List<OrderedRule>>> items;

--- a/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
+++ b/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
@@ -78,7 +78,7 @@ public final class AnalyzerUtil {
             if (classRules != null)
                 candidates.addAll(classRules);
         }
-        log.trace("After CLASSes {} total candidates.", candidates.size());
+        // log.trace("After CLASSes {} total candidates.", candidates.size());
 
         // match IDs
         final String id = ElementUtil.elementID(e);
@@ -87,7 +87,7 @@ public final class AnalyzerUtil {
             if (idRules != null)
                 candidates.addAll(idRules);
         }
-        log.trace("After IDs {} total candidates.", candidates.size());
+        // log.trace("After IDs {} total candidates.", candidates.size());
         
         // match elements
         final String name = ElementUtil.elementName(e);
@@ -96,14 +96,15 @@ public final class AnalyzerUtil {
             if (nameRules != null)
                 candidates.addAll(nameRules);
         }
-        log.trace("After ELEMENTs {} total candidates.", candidates.size());
+        // log.trace("After ELEMENTs {} total candidates.", candidates.size());
 
         // others
         candidates.addAll(holder.get(HolderItem.OTHER, null));
 
         final int totalCandidates = candidates.size();
         final int netCandidates = elementRuleSets == null ? totalCandidates : totalCandidates + elementRuleSets.length;
-        log.debug("Totally {} candidates.", totalCandidates);
+
+        // log.debug("Totally {} candidates.", totalCandidates);
 
         // transform to array to speed up traversal
         // and sort rules in order as they were found in CSS definition

--- a/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
+++ b/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
@@ -118,7 +118,8 @@ public final class AnalyzerUtil {
           }
         }
 
-        log.trace("With values: {}", Arrays.toString(clist));
+        // NOTE: The following trace statement creates a lot of memory pressure
+        // log.trace("With values: {}", Arrays.toString(clist));
 
         return clist;
 	}

--- a/src/main/java/cz/vutbr/web/domassign/Traversal.java
+++ b/src/main/java/cz/vutbr/web/domassign/Traversal.java
@@ -49,9 +49,8 @@ public abstract class Traversal<T>
     public void levelTraversal(T result) {
 
         // this method can change position in walker
-        Node current, checkpoint = null;
-        current = checkpoint = walker.getCurrentNode();
-        processNode(result, current, source);
+        final Node checkpoint = walker.getCurrentNode();
+        processNode(result, checkpoint, source);
         walker.setCurrentNode(checkpoint);
 
         // traverse children:

--- a/src/main/java/cz/vutbr/web/domassign/Traversal.java
+++ b/src/main/java/cz/vutbr/web/domassign/Traversal.java
@@ -54,8 +54,7 @@ public abstract class Traversal<T>
         walker.setCurrentNode(checkpoint);
 
         // traverse children:
-        for (Node n = walker.firstChild(); n != null; n = walker
-                .nextSibling()) {
+        for (Node n = walker.firstChild(); n != null; n = walker.nextSibling()) {
             levelTraversal(result);
         }
 
@@ -63,8 +62,7 @@ public abstract class Traversal<T>
         walker.setCurrentNode(checkpoint);
     }
 
-    protected abstract void processNode(T result, Node current,
-            Object source);
+    protected abstract void processNode(T result, Node current, Object source);
 
     public Traversal<T> reset(TreeWalker walker, Object source) {
         this.walker = walker;


### PR DESCRIPTION
Hi @radkovo 

I spent the last week in benchmarking `gngr` and identifying the bottlenecks. The biggest bottleneck was the "css analysis" pass. We were creating a new analyser for every element, because there was no way to specify per element rules to the analyser.

With the small changes in this PR, we are now able to get a huge performance boost. Our benchmark page (modelled after Reddit) now loads in 11seconds v/s the earlier load-time of 25 seconds!

### Summary of changes
A new method called `getClassfiedRules` has been carved out, that returns the `Holder` object. This allows us to cache the `Holder` object at the document level and re-use it for every descendant element.

There are minor cleanups which I have split into separate commits, so that it is easier for review.