### PR TITLE
Fix ordering and a rare exception

### DIFF
--- a/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
+++ b/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
@@ -140,8 +140,9 @@ public final class AnalyzerUtil {
 	 */
 	static void classifyAllSheets(final List<StyleSheet> sheets, final Holder rules, final MediaSpec mediaspec)
 	{
+		final Counter orderCounter = new Counter();
 	    for (final StyleSheet sheet : sheets)
-	        classifyRules(sheet, mediaspec, rules);
+	        classifyRules(sheet, mediaspec, rules, orderCounter);
 	}
 	
 	static boolean elementSelectorMatches(final Selector s, final Element e, final MatchCondition matchCond) {
@@ -448,9 +449,9 @@ public final class AnalyzerUtil {
 	 * 
 	 * @param sheet The style sheet to be classified
      * @param mediaspec The specification of the media for evaluating the media queries.
+	 * @param orderCounter 
 	 */
-	private static void classifyRules(final StyleSheet sheet, final MediaSpec mediaspec, final Holder rules) {
-		final Counter orderCounter = new Counter();
+	private static void classifyRules(final StyleSheet sheet, final MediaSpec mediaspec, final Holder rules, final Counter orderCounter) {
 
 		for (final Rule<?> rule : sheet) {
 			// this rule conforms to all media

--- a/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
+++ b/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
@@ -113,7 +113,7 @@ public final class AnalyzerUtil {
 
         // Append the element rules
         if (elementRuleSets != null) {
-          final int lastOrder = clist[totalCandidates-1].getOrder();
+          final int lastOrder = totalCandidates > 0 ? clist[totalCandidates-1].getOrder() : 0;
           for (int i = 0; i < elementRuleSets.length; i++) {
             clist[totalCandidates + i] = new OrderedRule(elementRuleSets[i], lastOrder + i);
           }


### PR DESCRIPTION
This has two fixes (in two commits):

* Use a common counter across stylesheets, when classifying rules. Without this, rules get haphazardly sorted across style-sheets!
* handle a rare scenario: no stylesheets present, but per-element rules are present.