### PR TITLE
Match empty

### DIFF
--- a/src/main/java/cz/vutbr/web/css/MediaSpec.java
+++ b/src/main/java/cz/vutbr/web/css/MediaSpec.java
@@ -115,9 +115,6 @@ public class MediaSpec
     /** 1 for a grid device, 0 for bitmap device */
     protected int grid;
     
-    /** Matches an empty media query? */
-    protected boolean matchEmpty;
-    
     /**
      * Creates a new media specification with the given media type and default values of the features.
      * @param type The media type (e.g. "screen")
@@ -126,7 +123,6 @@ public class MediaSpec
     {
         loadDefaults();
         this.type = type.trim().toLowerCase(Locale.ENGLISH);
-        this.matchEmpty = true; //normally, an empty media query means any media
     }
 
     /**
@@ -366,15 +362,6 @@ public class MediaSpec
     public boolean isPortrait()
     {
         return height >= width; //http://www.w3.org/TR/css3-mediaqueries/#orientation
-    }
-    
-    /**
-     * Sets whether this media specification should match empty media queries.
-     * @param matchEmpty {@code true} when this media specification should match empty media queries (this is the default)
-     */
-    public void setMatchEmpty(boolean matchEmpty)
-    {
-        this.matchEmpty = matchEmpty;
     }
     
     //===============================================================================================

--- a/src/main/java/cz/vutbr/web/css/MediaSpecNone.java
+++ b/src/main/java/cz/vutbr/web/css/MediaSpecNone.java
@@ -8,14 +8,14 @@ package cz.vutbr.web.css;
 import java.util.List;
 
 /**
- * A specific case of media specification that does not match to any media quert and expression.
+ * A specific case of media specification that does not match any media query or expression.
  * @author burgetr
  */
 public class MediaSpecNone extends MediaSpec
 {
 
     /**
-     * Creates the media specification that does not match to any media quert and expression.
+     * Creates the media specification that does not match any media query or expression.
      */
     public MediaSpecNone()
     {

--- a/src/main/java/cz/vutbr/web/css/MediaSpecNone.java
+++ b/src/main/java/cz/vutbr/web/css/MediaSpecNone.java
@@ -20,7 +20,6 @@ public class MediaSpecNone extends MediaSpec
     public MediaSpecNone()
     {
         super("!");
-        setMatchEmpty(false); //do not match empty media queries
     }
 
     @Override

--- a/src/main/java/cz/vutbr/web/css/MediaSpecNone.java
+++ b/src/main/java/cz/vutbr/web/css/MediaSpecNone.java
@@ -40,6 +40,12 @@ public class MediaSpecNone extends MediaSpec
     {
         return false;
     }
+    
+    @Override
+    public boolean matchesEmpty()
+    {
+        return false;
+    }
 
     @Override
     public String toString()

--- a/src/test/java/test/MediaTest.java
+++ b/src/test/java/test/MediaTest.java
@@ -6,6 +6,7 @@
 package test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.util.Date;
@@ -16,6 +17,7 @@ import cz.vutbr.web.css.CSSFactory;
 import cz.vutbr.web.css.MediaQuery;
 import cz.vutbr.web.css.RuleMedia;
 import cz.vutbr.web.css.StyleSheet;
+import cz.vutbr.web.css.MediaSpecNone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -152,5 +154,11 @@ public class MediaTest
     {
         StyleSheet ss = CSSFactory.parseString(TEST_MALFORMED4, null);
         assertEquals("There are three rules", 3, ss.size());
+    }
+    
+    @Test
+    public void matchesEmpty()
+    {
+        assertFalse("MediaSpecNone does not match the empty media query", (new MediaSpecNone()).matchesEmpty());
     }
 }

--- a/src/test/java/test/MediaTest.java
+++ b/src/test/java/test/MediaTest.java
@@ -7,6 +7,7 @@ package test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Date;
@@ -18,6 +19,7 @@ import cz.vutbr.web.css.MediaQuery;
 import cz.vutbr.web.css.RuleMedia;
 import cz.vutbr.web.css.StyleSheet;
 import cz.vutbr.web.css.MediaSpecNone;
+import cz.vutbr.web.css.MediaSpecAll;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -159,6 +161,7 @@ public class MediaTest
     @Test
     public void matchesEmpty()
     {
+        assertTrue("MediaSpecAll matches the empty media query", (new MediaSpecAll()).matchesEmpty());
         assertFalse("MediaSpecNone does not match the empty media query", (new MediaSpecNone()).matchesEmpty());
     }
 }


### PR DESCRIPTION
Resolves #53.

Removes the unused `matchEmpty` field in MediaSpec, and instead overrides `matchesEmpty()` in MediaSpecNone.