### PR TITLE
Fix for infinite loop when there are two adjacent @charset rules

### DIFF
--- a/src/main/antlr3/CSSLexer.g
+++ b/src/main/antlr3/CSSLexer.g
@@ -164,6 +164,7 @@ CHARSET
 	    //System.err.println("CHARSET"+tokencnt);
 	    if (tokencnt <= 1) //we are at the beginning of the style sheet
 	    {
+			    tokencnt++;
 			    try {
 			           log.warn("Changing charset to {}", enc);
 			          ((cz.vutbr.web.csskit.antlr.CSSInputStream) input).setEncoding(enc);


### PR DESCRIPTION
Consider an imported stylesheet that contains two adjacent `@charset` rules:

```
@charset "xyz";@charset "pqr";
```

The current code accepts the second `@charset` rule because the token-count is not incremented after the first `@charset` rule. Since the parsing is restarted when a `@charset` rule is processed and the new charset value differs from the previous value, the parser goes into an infinite loop.

This change fixes this by ensuring that the token-count is incremented and hence, the second `@charset` rule is ignored.

I have tested this change with `gngr` and the whole CSS2.1 test suite.