### PR TITLE
Encapsulate DeclarationTransformer in an interface

### DIFF
--- a/src/main/java/cz/vutbr/web/css/CSSFactory.java
+++ b/src/main/java/cz/vutbr/web/css/CSSFactory.java
@@ -17,12 +17,13 @@ import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 import org.w3c.dom.traversal.NodeFilter;
 
+import cz.vutbr.web.csskit.DeclarationTransformer;
 import cz.vutbr.web.csskit.DefaultNetworkProcessor;
 import cz.vutbr.web.csskit.MatchConditionImpl;
 import cz.vutbr.web.csskit.antlr4.CSSParserFactory;
 import cz.vutbr.web.csskit.antlr4.CSSParserFactory.SourceType;
 import cz.vutbr.web.domassign.Analyzer;
-import cz.vutbr.web.domassign.DeclarationTransformer;
+import cz.vutbr.web.domassign.DeclarationTransformerImpl;
 import cz.vutbr.web.domassign.StyleMap;
 import cz.vutbr.web.domassign.Traversal;
 
@@ -54,7 +55,7 @@ public final class CSSFactory {
 	private static final String DEFAULT_TERM_FACTORY = "cz.vutbr.web.csskit.TermFactoryImpl";
 	private static final String DEFAULT_SUPPORTED_CSS = "cz.vutbr.web.domassign.SupportedCSS3";
 	private static final String DEFAULT_RULE_FACTORY = "cz.vutbr.web.csskit.RuleFactoryImpl";
-    private static final String DEFAULT_DECLARATION_TRANSFORMER = "cz.vutbr.web.domassign.DeclarationTransformer";
+    private static final String DEFAULT_DECLARATION_TRANSFORMER = "cz.vutbr.web.domassign.DeclarationTransformerImpl";
 	private static final String DEFAULT_NODE_DATA_IMPL = "cz.vutbr.web.domassign.SingleMapNodeData";
 	private static final String DEFAULT_ELEMENT_MATCHER = "cz.vutbr.web.csskit.ElementMatcherSafeStd";
 
@@ -295,10 +296,10 @@ public final class CSSFactory {
         if (dt == null) {
             try {
                 @SuppressWarnings("unchecked")
-                Class<? extends DeclarationTransformer> clazz = (Class<? extends DeclarationTransformer>) Class
+                Class<? extends DeclarationTransformerImpl> clazz = (Class<? extends DeclarationTransformerImpl>) Class
                         .forName(DEFAULT_DECLARATION_TRANSFORMER);
                 Method m = clazz.getMethod("getInstance");
-                registerDeclarationTransformer((DeclarationTransformer) m.invoke(null));
+                registerDeclarationTransformer((DeclarationTransformerImpl) m.invoke(null));
                 log.debug("Retrived {} as default DeclarationTransformer implementation.",
                         DEFAULT_DECLARATION_TRANSFORMER);
             } catch (Exception e) {

--- a/src/main/java/cz/vutbr/web/csskit/DeclarationTransformer.java
+++ b/src/main/java/cz/vutbr/web/csskit/DeclarationTransformer.java
@@ -1,0 +1,13 @@
+package cz.vutbr.web.csskit;
+
+import java.util.Map;
+
+import cz.vutbr.web.css.CSSProperty;
+import cz.vutbr.web.css.Declaration;
+import cz.vutbr.web.css.Term;
+
+public interface DeclarationTransformer
+{
+  boolean parseDeclaration(Declaration d,
+      Map<String, CSSProperty> properties, Map<String, Term<?>> values);
+}

--- a/src/main/java/cz/vutbr/web/domassign/DeclarationTransformerImpl.java
+++ b/src/main/java/cz/vutbr/web/domassign/DeclarationTransformerImpl.java
@@ -39,6 +39,7 @@ import cz.vutbr.web.css.TermNumber;
 import cz.vutbr.web.css.TermPercent;
 import cz.vutbr.web.css.TermString;
 import cz.vutbr.web.css.TermURI;
+import cz.vutbr.web.csskit.DeclarationTransformer;
 import cz.vutbr.web.css.CSSProperty.BackgroundAttachment;
 import cz.vutbr.web.css.CSSProperty.BackgroundColor;
 import cz.vutbr.web.css.CSSProperty.BackgroundImage;
@@ -114,10 +115,10 @@ import cz.vutbr.web.css.Term.Operator;
  * @author kapy
  * 
  */
-public class DeclarationTransformer {
+public class DeclarationTransformerImpl implements DeclarationTransformer {
 
 	private static final Logger log = LoggerFactory
-			.getLogger(DeclarationTransformer.class);
+			.getLogger(DeclarationTransformerImpl.class);
 
 	/**
 	 * A hint about the allowed value range when processing numeric values. 
@@ -145,13 +146,13 @@ public class DeclarationTransformer {
 	/**
 	 * Singleton instance
 	 */
-	private static final DeclarationTransformer instance;
+	private static final DeclarationTransformerImpl instance;
 
 	private static final TermFactory tf = CSSFactory.getTermFactory();
 	private static final SupportedCSS css = CSSFactory.getSupportedCSS();
 
 	static {
-		instance = new DeclarationTransformer();
+		instance = new DeclarationTransformerImpl();
 	}
 
 	/**
@@ -159,7 +160,7 @@ public class DeclarationTransformer {
 	 * 
 	 * @return Singleton instance
 	 */
-	public static final DeclarationTransformer getInstance() {
+	public static final DeclarationTransformerImpl getInstance() {
 		return instance;
 	}
 
@@ -205,6 +206,7 @@ public class DeclarationTransformer {
 	 * @return <code>true</code> in case of success, <code>false</code>
 	 *         otherwise
 	 */
+	@Override
 	public boolean parseDeclaration(Declaration d,
 			Map<String, CSSProperty> properties, Map<String, Term<?>> values) {
 
@@ -243,7 +245,7 @@ public class DeclarationTransformer {
 	/**
 	 * Sole constructor
 	 */
-	private DeclarationTransformer() {
+	private DeclarationTransformerImpl() {
 		this.methods = parsingMethods();
 	}
 
@@ -254,8 +256,8 @@ public class DeclarationTransformer {
 
 		for (String key : css.getDefinedPropertyNames()) {
 			try {
-				Method m = DeclarationTransformer.class.getDeclaredMethod(
-						DeclarationTransformer.camelCase("process-" + key),
+				Method m = DeclarationTransformerImpl.class.getDeclaredMethod(
+						DeclarationTransformerImpl.camelCase("process-" + key),
 						Declaration.class, Map.class, Map.class);
 				map.put(key, m);
 			} catch (Exception e) {

--- a/src/main/java/cz/vutbr/web/domassign/QuadrupleMapNodeData.java
+++ b/src/main/java/cz/vutbr/web/domassign/QuadrupleMapNodeData.java
@@ -16,6 +16,7 @@ import cz.vutbr.web.css.Declaration;
 import cz.vutbr.web.css.NodeData;
 import cz.vutbr.web.css.SupportedCSS;
 import cz.vutbr.web.css.Term;
+import cz.vutbr.web.csskit.DeclarationTransformer;
 import cz.vutbr.web.csskit.OutputUtil;
 
 /**

--- a/src/main/java/cz/vutbr/web/domassign/SingleMapNodeData.java
+++ b/src/main/java/cz/vutbr/web/domassign/SingleMapNodeData.java
@@ -14,6 +14,7 @@ import cz.vutbr.web.css.Declaration;
 import cz.vutbr.web.css.NodeData;
 import cz.vutbr.web.css.SupportedCSS;
 import cz.vutbr.web.css.Term;
+import cz.vutbr.web.csskit.DeclarationTransformer;
 import cz.vutbr.web.csskit.OutputUtil;
 
 /**


### PR DESCRIPTION
I encapsulated the DeclarationTransformer in an interface to be able to set a custom implementatino in CSSFactory. I thought this should be possible because the factory already contains a setter method but the DeclarationTransformer with its private constructor was near final and not extendable. I did it in the way you already did with the SupportedCSS instance.