### PR TITLE
Properly parse vendor-specific pseudos

### DIFF
--- a/src/main/java/cz/vutbr/web/css/RuleFactory.java
+++ b/src/main/java/cz/vutbr/web/css/RuleFactory.java
@@ -145,7 +145,7 @@ public interface RuleFactory {
 	 * @param functionName Name of additional function or <code>null</code>
 	 * @return New CSS pseudo page selector page
 	 */
-	Selector.PseudoPage createPseudoPage(String pseudo, String functionName);
+	Selector.PseudoPage createPseudoPage(String pseudo, String functionName, boolean isPseudoElement);
 
     /**
      * Creates CSS pseudo selector containing another selector as argument

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -101,8 +101,8 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         SPELLING_ERROR("spelling-error", true),
         
         // Placeholders for vendor-specific pseudo-classes or elements
-        VENDOR_CLASS("", false),
-        VENDOR_ELEMENT("", true);
+        vendor_class(null, false),
+        vendor_element(null, true);
 
         private String value;
         private boolean element;

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -63,6 +63,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
      */
     public enum PseudoDeclaration
     {
+        // Pseudo-classes
         ACTIVE("active", false),
         FOCUS("focus", false),
         HOVER("hover", false),
@@ -87,30 +88,21 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         TARGET("target", false),
         NOT("not", false),
         
+        // Pseudo-elements
         FIRST_LINE("first-line", true),
         FIRST_LETTER("first-letter", true),
         BEFORE("before", true),
         AFTER("after", true),
-        
         BACKDROP("backdrop", true),
         CUE("cue", true),
         GRAMMAR_ERROR("grammar-error", true),
         PLACEHOLDER("placeholder", true),
         SELECTION("selection", true),
         SPELLING_ERROR("spelling-error", true),
-        _MOZ_PROGRESS_BAR("-moz-progress-bar", true),
-        _MOZ_RANGE_PROGRESS("-moz-range-progress", true),
-        _MOZ_RANGE_THUMB("-moz-range-thumb", true),
-        _MOZ_RANGE_TRACK("-moz-range-track", true),
-        _MS_FILL("-ms-fill", true),
-        _MS_FILL_LOWER("-ms-fill-lower", true),
-        _MS_FILL_UPPER("-ms-fill-upper", true),
-        _MS_THUMB("-ms-thumb", true),
-        _MS_TRACK("-ms-track", true),
-        _WEBKIT_PROGRESS_BAR("-webkit-progress-bar", true),
-        _WEBKIT_PROGRESS_VALUE("-webkit-progress-value", true),
-        _WEBKIT_SLIDER_RUNNABLE_TRACK("-webkit-slider-runnable-track", true),
-        _WEBKIT_SLIDER_THUMB("-webkit-slider-thumb", true);
+        
+        // Placeholders for vendor-specific pseudo-classes or elements
+        VENDOR_CLASS("", false),
+        VENDOR_ELEMENT("", true);
 
         private String value;
         private boolean element;
@@ -265,7 +257,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
     	public PseudoPage setFunctionName(String functionName);
     	
     	public String getValue();
-    	public PseudoPage setValue(String value);
+    	public PseudoPage setValue(String value, boolean isPseudoElement);
     	
         public PseudoDeclaration getDeclaration();
         

--- a/src/main/java/cz/vutbr/web/csskit/RuleFactoryImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/RuleFactoryImpl.java
@@ -149,8 +149,8 @@ public class RuleFactoryImpl implements RuleFactory {
 		return new SelectorImpl.ElementIDImpl(id);
 	}
 	
-	public PseudoPage createPseudoPage(String pseudo, String functionName) {
-		return new SelectorImpl.PseudoPageImpl(pseudo, functionName);
+	public PseudoPage createPseudoPage(String pseudo, String functionName, boolean isPseudoElement) {
+		return new SelectorImpl.PseudoPageImpl(pseudo, functionName, isPseudoElement);
 	}
 	
     public PseudoPage createPseudoPage(Selector selector, String functionName) {

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -367,8 +367,8 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             PSEUDO_DECLARATIONS = new HashMap<>(PseudoDeclaration.values().length);
             
             for (PseudoDeclaration declaration : PseudoDeclaration.values()) {
-                if (declaration == PseudoDeclaration.VENDOR_CLASS || declaration == PseudoDeclaration.VENDOR_ELEMENT) {
-                    continue; // These do not have a specific associated key, so they should not be in the lookup table
+                if (declaration.value() == null) {
+                    continue;
                 }
                 
                 PSEUDO_DECLARATIONS.put(declaration.value(), declaration);
@@ -764,7 +764,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 		    if (functionName != null)
 		        declaration = PSEUDO_DECLARATIONS.get(functionName.toLowerCase()); //Pseudo-element and pseudo-class names are case-insensitive
 		    else if (value != null && value.startsWith("-")) // Vendor-specific
-                declaration = (isPseudoElement ? PseudoDeclaration.VENDOR_ELEMENT : PseudoDeclaration.VENDOR_CLASS);
+                declaration = (isPseudoElement ? PseudoDeclaration.vendor_element : PseudoDeclaration.vendor_class);
             else if (value != null)
 		        declaration = PSEUDO_DECLARATIONS.get(value.toLowerCase());
             else

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/CSSParserVisitorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/CSSParserVisitorImpl.java
@@ -1359,7 +1359,7 @@ public class CSSParserVisitorImpl implements CSSParserVisitor<Object>, CSSParser
             if (ctx.MINUS() != null) {
                 pseudo = ctx.MINUS().getText() + pseudo;
             }
-            pseudoPage = rf.createPseudoPage(pseudo, null);
+            pseudoPage = rf.createPseudoPage(pseudo, null, isPseudoElem);
             if (pseudoPage == null || pseudoPage.getDeclaration() == null) {
                 log.error("invalid pseudo declaration: " + pseudo);
                 pseudoPage = null;
@@ -1391,7 +1391,7 @@ public class CSSParserVisitorImpl implements CSSParserVisitor<Object>, CSSParser
                     } else {
                         throw new UnsupportedOperationException("unknown state");
                     }
-                    pseudoPage = rf.createPseudoPage(value, name);
+                    pseudoPage = rf.createPseudoPage(value, name, false);
                 }
             }
         }

--- a/src/test/java/test/PseudoClassTest.java
+++ b/src/test/java/test/PseudoClassTest.java
@@ -20,7 +20,11 @@ import org.xml.sax.SAXException;
 
 import cz.vutbr.web.css.CSSException;
 import cz.vutbr.web.css.CSSFactory;
+import cz.vutbr.web.css.CombinedSelector;
 import cz.vutbr.web.css.NodeData;
+import cz.vutbr.web.css.RuleFactory;
+import cz.vutbr.web.css.RuleSet;
+import cz.vutbr.web.css.Selector;
 import cz.vutbr.web.css.StyleSheet;
 import cz.vutbr.web.css.Selector.PseudoDeclaration;
 import cz.vutbr.web.css.TermColor;
@@ -28,11 +32,15 @@ import cz.vutbr.web.css.TermFactory;
 import cz.vutbr.web.csskit.MatchConditionOnElements;
 import cz.vutbr.web.domassign.DirectAnalyzer;
 import cz.vutbr.web.domassign.StyleMap;
+import java.util.List;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class PseudoClassTest {
 	private static final Logger log = LoggerFactory.getLogger(PseudoClassTest.class);
 	
 	private static TermFactory tf = CSSFactory.getTermFactory();
+    private static final RuleFactory rf = CSSFactory.getRuleFactory();
 	
 	@BeforeClass
 	public static void init() throws SAXException, IOException {
@@ -159,12 +167,32 @@ public class PseudoClassTest {
             "input[type=range]::-moz-range-thumb { width: 4em; }\n" +
             "input[type=range]::-ms-track { width: 5em; }\n" +
             "input[type=range]::-ms-thumb { width: 6em; }";
+    private static final String[] TEST_RANGE_ELEMENTS = new String[] {
+            "-webkit-slider-runnable-track",
+            "-webkit-slider-thumb",
+            "-moz-range-track",
+            "-moz-range-thumb",
+            "-ms-track",
+            "-ms-thumb"
+            };
     
     @Test
     public void rangeInputPseudoElements() throws CSSException, IOException {
         
         StyleSheet style = CSSFactory.parseString(TEST_RANGE, null);
         assertEquals("There are 6 rules", 6, style.size());
+        
+        for (int i = 0; i < TEST_RANGE_ELEMENTS.length; i++) {
+            List<CombinedSelector> cslist = SelectorsUtil.appendSimpleSelector(null, 
+                "input", 
+                null, 
+                rf.createAttribute("range", false, Selector.Operator.EQUALS, "type"), 
+                rf.createPseudoPage(TEST_RANGE_ELEMENTS[i], null, true));
+
+            RuleSet rule = (RuleSet) style.get(i);
+            assertArrayEquals("Rule contains one selector input[type=range]::" + TEST_RANGE_ELEMENTS[i], cslist.toArray(), rule.getSelectors());
+            assertEquals("Rule contains one declaration", 1, rule.size());
+        }
     }
     
     private NodeData getStyleById(ElementMap elements, StyleMap decl, String id)

--- a/src/test/java/test/SelectorTest.java
+++ b/src/test/java/test/SelectorTest.java
@@ -296,7 +296,7 @@ public class SelectorTest {
 
 		List<CombinedSelector> cslist = SelectorsUtil.appendCS(null);
 		SelectorsUtil.appendSimpleSelector(cslist, null, null, rf
-				.createPseudoPage("hover", null));
+				.createPseudoPage("hover", null, false));
 
 		assertArrayEquals("Rule contains one pseudoselector :hover", cslist.toArray(), rule
 				.getSelectors());
@@ -317,7 +317,7 @@ public class SelectorTest {
 
 		List<CombinedSelector> cslist = SelectorsUtil.appendCS(null);
 		SelectorsUtil.appendSimpleSelector(cslist, null, null, rf
-				.createPseudoPage("fr", "lang"));
+				.createPseudoPage("fr", "lang", false));
 		SelectorsUtil.appendChild(cslist, "Q");
 
 		assertArrayEquals("Rule contains one combined pseudoselector :lang(fr)>Q",
@@ -341,7 +341,7 @@ public class SelectorTest {
 		// test first rule
 		List<CombinedSelector> cslist = SelectorsUtil.appendCS(null);
 		SelectorsUtil.appendSimpleSelector(cslist, "P", null, rf
-				.createClass("special"), rf.createPseudoPage("before", null));
+				.createClass("special"), rf.createPseudoPage("before", null, true));
 
 		assertArrayEquals("Rule 1 contains one combined selector P.special:before",
 				cslist.toArray(), ((RuleSet) ss.get(0)).getSelectors());
@@ -356,7 +356,7 @@ public class SelectorTest {
 		cslist = SelectorsUtil.appendCS(null);
 		SelectorsUtil.appendSimpleSelector(cslist, "P", null, rf
 				.createClass("special"), rf.createPseudoPage("first-letter",
-				null));
+				null, true));
 
 		assertArrayEquals(
 				"Rule 2 contains one combined selector P.special:first-letter",


### PR DESCRIPTION
This replaces the hard-coded vendor-specific pseudo-elements by generic placeholders `VENDOR_CLASS` and `VENDOR_ELEMENT`, and updates the parser to work with them.

I had to pass a new flag that determines whether a vendor-prefixed pseudo is a pseudo-class or pseudo-element, since we can't determine this from the value as happens for known pseudos.