### PR TITLE
Improved pseudo

### DIFF
--- a/src/main/antlr4/cz/vutbr/web/csskit/antlr4/CSSParser.g4
+++ b/src/main/antlr4/cz/vutbr/web/csskit/antlr4/CSSParser.g4
@@ -108,20 +108,13 @@ import_uri
     }
 
 page
-	: PAGE S* IDENT? page_pseudo? S*
+	: PAGE S* IDENT? pseudo? S*
 		LCURLY S*
 		declarations margin_rule*
 		RCURLY
 	;
     catch [RecognitionException re] {
         log.error("Recognition exception | page | should be empty");
-    }
-
-page_pseudo
-	: pseudocolon
-	;
-    catch [RecognitionException re] {
-        log.error("Recognition exception | page_pseudo | should be empty");
     }
 
 /** CSS3 margin-at-rule - see https://drafts.csswg.org/css-page-3/#margin-at-rules */
@@ -433,20 +426,12 @@ attribute
      }
 
 pseudo
-	: pseudocolon (MINUS? IDENT | FUNCTION S* (MINUS? IDENT | MINUS? NUMBER | MINUS? INDEX | selector) S* RPAREN)
-	;
+    : COLON COLON? (MINUS? IDENT | FUNCTION S* (MINUS? IDENT | MINUS? NUMBER | MINUS? INDEX | selector) S* RPAREN)
+    ;
     catch [RecognitionException re] {
       log.error("PARSING pseudo ERROR | inserting INVALID_SELPART");
        _localctx.addErrorNode(this.getTokenFactory().create(INVALID_SELPART, "INVALID_SELPART"));
     }
-
-pseudocolon
-	: COLON COLON // pseudo element
-	| COLON // pseudo class
-	;
-    catch [RecognitionException re] {
-        log.error("PARSING pseudocolon ERROR | should be empty");
-     }
 
 
 string

--- a/src/main/java/cz/vutbr/web/css/CombinedSelector.java
+++ b/src/main/java/cz/vutbr/web/css/CombinedSelector.java
@@ -1,7 +1,5 @@
 package cz.vutbr.web.css;
 
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
-
 /**
  * CombinedSelector of CSS declaration block.
  * Acts as collection of Selectors with ability to get directly 
@@ -26,7 +24,7 @@ public interface CombinedSelector extends Rule<Selector> {
      * Reads the pseudo element of the last simple selector as defined in the CSS specs
      * @return the pseudo-element or null if none is specified
      */
-    public PseudoDeclaration getPseudoElement();
+    public Selector.PseudoElementType getPseudoElementType();
     
     /**
      * Computes specificity according to the CSS rules

--- a/src/main/java/cz/vutbr/web/css/RuleFactory.java
+++ b/src/main/java/cz/vutbr/web/css/RuleFactory.java
@@ -139,21 +139,58 @@ public interface RuleFactory {
 	 */
 	Selector.ElementID createID(String id);
 
-	/**
-	 * Creates CSS selector part, pseudo page
-	 * @param pseudo Name of pseudo page
-	 * @param functionName Name of additional function or <code>null</code>
-	 * @return New CSS pseudo page selector page
-	 */
-	Selector.PseudoPage createPseudoPage(String pseudo, String functionName, boolean isPseudoElement);
-
     /**
-     * Creates CSS pseudo selector containing another selector as argument
-     * @param selector the nested selector
-     * @param functionName Name of pseudo function
-     * @return New CSS pseudo page selector page
-     */
-    Selector.PseudoPage createPseudoPage(Selector selector, String functionName);
+	 * Creates CSS selector part, page at-rule pseudo-class
+	 * @param name Name of pseudo-class
+	 * @return New CSS page pseudo-class
+	 */
+	Selector.PseudoPage createPseudoPage(String name);
+    
+    /**
+	 * Creates CSS selector part, pseudo-element
+	 * @param name Name of pseudo-element
+	 * @return New CSS pseudo-element
+	 */
+	Selector.PseudoElement createPseudoElement(String name);
+    
+    /**
+	 * Creates CSS selector part, pseudo-element
+	 * @param name Name of pseudo-element
+     * @param functionValue Value of its function argument
+	 * @return New CSS pseudo-element
+	 */
+	Selector.PseudoElement createPseudoElement(String name, String functionValue);
+    
+    /**
+	 * Creates CSS selector part, pseudo-element
+	 * @param name Name of pseudo-element
+     * @param nestedSelector Selector in its function argument
+	 * @return New CSS pseudo-element
+	 */
+	Selector.PseudoElement createPseudoElement(String name, Selector nestedSelector);
+    
+	/**
+	 * Creates CSS selector part, pseudo-class
+	 * @param name Name of pseudo-class
+	 * @return New CSS pseudo-class
+	 */
+	Selector.PseudoClass createPseudoClass(String name);
+    
+    /**
+	 * Creates CSS selector part, pseudo-class
+	 * @param name Name of pseudo-class
+     * @param functionValue Value of its function argument
+	 * @return New CSS pseudo-class
+	 */
+	Selector.PseudoClass createPseudoClass(String name, String functionValue);
+    
+    /**
+	 * Creates CSS selector part, pseudo-class
+	 * @param name Name of pseudo-class
+     * @param nestedSelector Selector in its function argument
+	 * @return New CSS pseudo-class
+	 */
+	Selector.PseudoClass createPseudoClass(String name, Selector nestedSelector);
 
 	/**
 	 * Creates CSS author style sheet

--- a/src/main/java/cz/vutbr/web/css/RulePage.java
+++ b/src/main/java/cz/vutbr/web/css/RulePage.java
@@ -27,13 +27,13 @@ public interface RulePage extends RuleBlock<Rule<?>>, PrettyOutput {
 	 * Gets pseudo-class of the page
 	 * @return Pseudo-class of the page
 	 */
-    public String getPseudo();
+    public Selector.PseudoPage getPseudo();
     
     /**
      * Sets pseudo-class of the page
      * @param pseudo New pseudo-class of the page
      * @return Modified instance
      */
-    public RulePage setPseudo(String pseudo);
+    public RulePage setPseudo(Selector.PseudoPage pseudo);
 
 }

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -67,6 +67,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         ACTIVE("active", false),
         ANY("any", false),
         ANY_LINK("any-link", false),
+        BLANK("blank", false),
         CHECKED("checked", false),
         DEFAULT("default", false),
         DEFINED("defined", false),

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -1,5 +1,7 @@
 package cz.vutbr.web.css;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.w3c.dom.Element;
 
 /**
@@ -58,86 +60,164 @@ public interface Selector extends Rule<Selector.SelectorPart> {
     }
 
     /**
-     * A pseudo class or element specification 
-     * @author burgetr
+     * A pseudo-class for @page rules
      */
-    public enum PseudoDeclaration
-    {
-        // Pseudo-classes
-        ACTIVE("active", false),
-        ANY("any", false),
-        ANY_LINK("any-link", false),
-        BLANK("blank", false),
-        CHECKED("checked", false),
-        DEFAULT("default", false),
-        DEFINED("defined", false),
-        DIR("dir", false),
-        DISABLED("disabled", false),
-        EMPTY("empty", false),
-        ENABLED("enabled", false),
-        FIRST("first", false),
-        FIRST_CHILD("first-child", false),
-        FIRST_OF_TYPE("first-of-type", false),
-        FULLSCREEN("fullscreen", false),
-        FOCUS("focus", false),
-        FOCUS_WITHIN("focus-within", false),
-        HOVER("hover", false),
-        INDETERMINATE("indeterminate", false),
-        IN_RANGE("in-range", false),
-        INVALID("invalid", false),
-        LANG("lang", false),
-        LAST_CHILD("last-child", false),
-        LAST_OF_TYPE("last-of-type", false),
-        LEFT("left", false),
-        LINK("link", false),
-        NOT("not", false),
-        NTH_CHILD("nth-child", false),
-        NTH_LAST_CHILD("nth-last-child", false),
-        NTH_LAST_OF_TYPE("nth-last-of-type", false),
-        NTH_OF_TYPE("nth-of-type", false),
-        ONLY_CHILD("only-child", false),
-        ONLY_OF_TYPE("only-of-type", false),
-        OPTIONAL("optional", false),
-        OUT_OF_RANGE("out-of-range", false),
-        PLACEHOLDER_SHOWN("placeholder-shown", false),
-        READ_ONLY("read-only", false),
-        READ_WRITE("read-write", false),
-        REQUIRED("required", false),
-        RIGHT("right", false),
-        ROOT("root", false),
-        SCOPE("scope", false),
-        TARGET("target", false),
-        VALID("valid", false),
-        VISITED("visited", false),
+    public enum PseudoPageType {
+        BLANK("blank"),
+        FIRST("first"),
+        LEFT("left"),
+        RIGHT("right"),
+        vendor(null); // Vendor-prefixed
         
-        // Pseudo-elements
-        FIRST_LINE("first-line", true),
-        FIRST_LETTER("first-letter", true),
-        BEFORE("before", true),
-        AFTER("after", true),
-        BACKDROP("backdrop", true),
-        CUE("cue", true),
-        GRAMMAR_ERROR("grammar-error", true),
-        PLACEHOLDER("placeholder", true),
-        SELECTION("selection", true),
-        SPELLING_ERROR("spelling-error", true),
+        private final String name;
+        private static final Map<String, PseudoPageType> lookup = new ConcurrentHashMap<>();
         
-        // Placeholders for vendor-specific pseudo-classes or elements
-        vendor_class(null, false),
-        vendor_element(null, true);
-
-        private String value;
-        private boolean element;
-        
-        private PseudoDeclaration(String value, boolean isElement) {
-            this.value = value;
-            this.element = isElement;
+        private PseudoPageType(String name) {
+            this.name = name;
         }
         
-        public String value() {return value;}
+        public String getName() {
+            return name;
+        }
         
-        public boolean isPseudoElement() {return element;}
+        public static PseudoPageType forName(String name) {
+            if (name == null) {
+                return null;
+            }
+            if (name.startsWith("-") || name.startsWith("_")) {
+                return vendor;
+            }
+            if (lookup.isEmpty()) {
+                for (PseudoPageType type : values()) {
+                    if (type.getName() != null) {
+                        lookup.put(type.getName(), type);
+                    }
+                }
+            }
+            return lookup.get(name.toLowerCase());
+        }
+    }
+    
+    /**
+     * A pseudo-class
+     */
+    public enum PseudoClassType {
+        ACTIVE("active"),
+        ANY("any"),
+        ANY_LINK("any-link"),
+        CHECKED("checked"),
+        DEFAULT("default"),
+        DEFINED("defined"),
+        DIR("dir"),
+        DISABLED("disabled"),
+        EMPTY("empty"),
+        ENABLED("enabled"),
+        FIRST_CHILD("first-child"),
+        FIRST_OF_TYPE("first-of-type"),
+        FULLSCREEN("fullscreen"),
+        FOCUS("focus"),
+        FOCUS_WITHIN("focus-within"),
+        HAS("has"),
+        HOVER("hover"),
+        INDETERMINATE("indeterminate"),
+        IN_RANGE("in-range"),
+        INVALID("invalid"),
+        LANG("lang"),
+        LAST_CHILD("last-child"),
+        LAST_OF_TYPE("last-of-type"),
+        LINK("link"),
+        NOT("not"),
+        NTH_CHILD("nth-child"),
+        NTH_LAST_CHILD("nth-last-child"),
+        NTH_LAST_OF_TYPE("nth-last-of-type"),
+        NTH_OF_TYPE("nth-of-type"),
+        ONLY_CHILD("only-child"),
+        ONLY_OF_TYPE("only-of-type"),
+        OPTIONAL("optional"),
+        OUT_OF_RANGE("out-of-range"),
+        PLACEHOLDER_SHOWN("placeholder-shown"),
+        READ_ONLY("read-only"),
+        READ_WRITE("read-write"),
+        REQUIRED("required"),
+        ROOT("root"),
+        SCOPE("scope"),
+        TARGET("target"),
+        VALID("valid"),
+        VISITED("visited"),
+        vendor(null); // Vendor-prefixed
         
+        private final String name;
+        private static final Map<String, PseudoClassType> lookup = new ConcurrentHashMap<>();
+        
+        private PseudoClassType(String name) {
+            this.name = name;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public static PseudoClassType forName(String name) {
+            if (name == null) {
+                return null;
+            }
+            if (name.startsWith("-") || name.startsWith("_")) {
+                return vendor;
+            }
+            if (lookup.isEmpty()) {
+                for (PseudoClassType type : values()) {
+                    if (type.getName() != null) {
+                        lookup.put(type.getName(), type);
+                    }
+                }
+            }
+            return lookup.get(name.toLowerCase());
+        }
+    }
+    
+    /**
+     * A pseudo-element
+     */
+    public enum PseudoElementType {
+        FIRST_LINE("first-line"),
+        FIRST_LETTER("first-letter"),
+        BEFORE("before"),
+        AFTER("after"),
+        BACKDROP("backdrop"),
+        CUE("cue"),
+        GRAMMAR_ERROR("grammar-error"),
+        PLACEHOLDER("placeholder"),
+        SELECTION("selection"),
+        SPELLING_ERROR("spelling-error"),
+        vendor(null); // Vendor-prefixed
+        
+        private final String name;
+        private static final Map<String, PseudoElementType> lookup = new ConcurrentHashMap<>();
+        
+        private PseudoElementType(String name) {
+            this.name = name;
+        }
+        
+        public String getName() {
+            return name;
+        }
+        
+        public static PseudoElementType forName(String name) {
+            if (name == null) {
+                return null;
+            }
+            if (name.startsWith("-") || name.startsWith("_")) {
+                return vendor;
+            }
+            if (lookup.isEmpty()) {
+                for (PseudoElementType type : values()) {
+                    if (type.getName() != null) {
+                        lookup.put(type.getName(), type);
+                    }
+                }
+            }
+            return lookup.get(name.toLowerCase());
+        }
     }
     
     /**
@@ -172,16 +252,17 @@ public interface Selector extends Rule<Selector.SelectorPart> {
     public String getElementName();
     
     /**
-     * Reads the pseudoelement of the selector 
+     * Reads the pseudo-element of the selector 
      * @return the used pseudo-element or <code>null</code> if no pseudo-element is specified
      */
-    public PseudoDeclaration getPseudoElement();
+    public PseudoElementType getPseudoElementType();
     
     /**
-     * Checks where the specified pseudo declaration is in this selector
-     * @return <code>true</code> if the selector has the specified pseudo declaration
+     * Checks where the specified pseudo-class is in this selector
+     * @param pct
+     * @return <code>true</code> if the selector has the specified pseudo-class
      */
-    public boolean hasPseudoDeclaration(final PseudoDeclaration pd);
+    public boolean hasPseudoClass(final PseudoClassType pct);
 
     /**
      * Modifies specificity according to CSS standard
@@ -269,16 +350,22 @@ public interface Selector extends Rule<Selector.SelectorPart> {
     	public ElementDOM setElement(Element e);
     }
     
-    /**
-     * Pseudo page
-     * @author kapy
-     *
-     */
     public interface PseudoPage extends SelectorPart {
-    	public String getFunctionName();
-    	public String getValue();
-        public PseudoDeclaration getDeclaration();
+    	public String getName();
+        public PseudoPageType getType();
     }
-       
-   
+    
+    public interface PseudoClass extends SelectorPart {
+        public String getName();
+        public String getFunctionValue();
+        public PseudoClassType getType();
+        public Selector getNestedSelector();
+    }
+    
+    public interface PseudoElement extends SelectorPart {
+        public String getName();
+        public String getFunctionValue();
+        public PseudoElementType getType();
+        public Selector getNestedSelector();
+    }
 }

--- a/src/main/java/cz/vutbr/web/csskit/CombinedSelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/CombinedSelectorImpl.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 
 import cz.vutbr.web.css.CombinedSelector;
 import cz.vutbr.web.css.Selector;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
 
 /**
  * CSS CombinedSelector with implementation of specificity
@@ -24,8 +23,9 @@ public class CombinedSelectorImpl extends AbstractRule<Selector> implements Comb
 		return list.get(list.size()-1);
 	}
 	
-    public PseudoDeclaration getPseudoElement() {
-        return getLastSelector().getPseudoElement(); //pseudo-elements may only be appended after the last simple selector of the selector
+    @Override
+    public Selector.PseudoElementType getPseudoElementType() {
+        return getLastSelector().getPseudoElementType(); //pseudo-elements may only be appended after the last simple selector of the selector
     }
 	
 	/**

--- a/src/main/java/cz/vutbr/web/csskit/MatchConditionImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/MatchConditionImpl.java
@@ -8,7 +8,8 @@ package cz.vutbr.web.csskit;
 import org.w3c.dom.Element;
 
 import cz.vutbr.web.css.MatchCondition;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.Selector.PseudoClass;
+import cz.vutbr.web.css.Selector.PseudoClassType;
 import cz.vutbr.web.css.Selector.PseudoPage;
 import cz.vutbr.web.css.Selector.SelectorPart;
 
@@ -19,21 +20,21 @@ import cz.vutbr.web.css.Selector.SelectorPart;
  */
 public class MatchConditionImpl implements MatchCondition
 {
-    PseudoDeclaration pseudo;
+    PseudoClassType pseudo;
     
     /**
-     * Creates the fefault condition that matches the LINK pseudo class to links.
+     * Creates the default condition that matches the LINK pseudo class to links.
      */
     public MatchConditionImpl()
     {
-        pseudo = PseudoDeclaration.LINK;
+        pseudo = PseudoClassType.LINK;
     }
     
     /**
-     * Creates the fefault condition that matches the given pseudo class to links.
+     * Creates the default condition that matches the given pseudo class to links.
      * @param pseudoClass the pseudoClass to be matched to links
      */
-    public MatchConditionImpl(PseudoDeclaration pseudoClass)
+    public MatchConditionImpl(PseudoClassType pseudoClass)
     {
         this.pseudo = pseudoClass;
     }
@@ -42,17 +43,17 @@ public class MatchConditionImpl implements MatchCondition
      * Sets the pseudo class that is matched to links.
      * @param pseudoClass the pseudoClass to be matched to links
      */
-    public void setPseudoClass(PseudoDeclaration pseudoClass)
+    public void setPseudoClass(PseudoClassType pseudoClass)
     {
         this.pseudo = pseudoClass;
     }
     
     public boolean isSatisfied(Element e, SelectorPart selpart)
     {
-        if (selpart instanceof PseudoPage)
+        if (selpart instanceof PseudoClass)
         {
-            PseudoDeclaration declaration = ((PseudoPage) selpart).getDeclaration();
-            return declaration.equals(pseudo) && e.getTagName().equalsIgnoreCase("a");
+            PseudoClassType type = ((PseudoClass) selpart).getType();
+            return type == pseudo && e.getTagName().equalsIgnoreCase("a");
         }
         else
             return false;

--- a/src/main/java/cz/vutbr/web/csskit/MatchConditionOnElements.java
+++ b/src/main/java/cz/vutbr/web/csskit/MatchConditionOnElements.java
@@ -13,8 +13,8 @@ import java.util.Set;
 import org.w3c.dom.Element;
 
 import cz.vutbr.web.css.MatchCondition;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
-import cz.vutbr.web.css.Selector.PseudoPage;
+import cz.vutbr.web.css.Selector.PseudoClass;
+import cz.vutbr.web.css.Selector.PseudoClassType;
 import cz.vutbr.web.css.Selector.SelectorPart;
 
 /**
@@ -27,8 +27,8 @@ import cz.vutbr.web.css.Selector.SelectorPart;
  */
 public class MatchConditionOnElements implements MatchCondition
 {
-    private Map<Element, Set<PseudoDeclaration>> elements;
-    private Map<String, Set<PseudoDeclaration>> names;
+    private Map<Element, Set<PseudoClassType>> elements;
+    private Map<String, Set<PseudoClassType>> names;
     
     /**
      * Creates the condition with an empty set of assigned elements and element names.
@@ -44,7 +44,7 @@ public class MatchConditionOnElements implements MatchCondition
      * @param e the element
      * @param pseudoClass the pseudo class to be assigned
      */
-    public MatchConditionOnElements(Element e, PseudoDeclaration pseudoClass)
+    public MatchConditionOnElements(Element e, PseudoClassType pseudoClass)
     {
         addMatch(e, pseudoClass);
     }
@@ -54,7 +54,7 @@ public class MatchConditionOnElements implements MatchCondition
      * @param name the element name
      * @param pseudoClass the pseudo class to be assigned
      */
-    public MatchConditionOnElements(String name, PseudoDeclaration pseudoClass)
+    public MatchConditionOnElements(String name, PseudoClassType pseudoClass)
     {
         addMatch(name, pseudoClass);
     }
@@ -64,15 +64,15 @@ public class MatchConditionOnElements implements MatchCondition
      * @param e the DOM element
      * @param pseudoClass the pseudo class to be assigned
      */
-    public void addMatch(Element e, PseudoDeclaration pseudoClass)
+    public void addMatch(Element e, PseudoClassType pseudoClass)
     {
         if (elements == null)
-            elements = new HashMap<Element, Set<PseudoDeclaration>>();
+            elements = new HashMap<Element, Set<PseudoClassType>>();
         
-        Set<PseudoDeclaration> classes = elements.get(e);
+        Set<PseudoClassType> classes = elements.get(e);
         if (classes == null)
         {
-            classes = new HashSet<PseudoDeclaration>(2);
+            classes = new HashSet<PseudoClassType>(2);
             elements.put(e, classes);
         }
         classes.add(pseudoClass);
@@ -83,11 +83,11 @@ public class MatchConditionOnElements implements MatchCondition
      * @param e the DOM element
      * @param pseudoClass the pseudo class to be removed
      */
-    public void removeMatch(Element e, PseudoDeclaration pseudoClass)
+    public void removeMatch(Element e, PseudoClassType pseudoClass)
     {
         if (elements != null)
         {
-            Set<PseudoDeclaration> classes = elements.get(e);
+            Set<PseudoClassType> classes = elements.get(e);
             if (classes != null)
                 classes.remove(pseudoClass);
         }   
@@ -99,15 +99,15 @@ public class MatchConditionOnElements implements MatchCondition
      * @param name the element name
      * @param pseudoClass the pseudo class to be assigned
      */
-    public void addMatch(String name, PseudoDeclaration pseudoClass)
+    public void addMatch(String name, PseudoClassType pseudoClass)
     {
         if (names == null)
-            names = new HashMap<String, Set<PseudoDeclaration>>();
+            names = new HashMap<String, Set<PseudoClassType>>();
         
-        Set<PseudoDeclaration> classes = names.get(name);
+        Set<PseudoClassType> classes = names.get(name);
         if (classes == null)
         {
-            classes = new HashSet<PseudoDeclaration>(2);
+            classes = new HashSet<PseudoClassType>(2);
             names.put(name, classes);
         }
         classes.add(pseudoClass);
@@ -118,11 +118,11 @@ public class MatchConditionOnElements implements MatchCondition
      * @param name the element name
      * @param pseudoClass the pseudo class to be removed
      */
-    public void removeMatch(String name, PseudoDeclaration pseudoClass)
+    public void removeMatch(String name, PseudoClassType pseudoClass)
     {
         if (names != null)
         {
-            Set<PseudoDeclaration> classes = names.get(name);
+            Set<PseudoClassType> classes = names.get(name);
             if (classes != null)
                 classes.remove(pseudoClass);
         }   
@@ -130,20 +130,20 @@ public class MatchConditionOnElements implements MatchCondition
     
     public boolean isSatisfied(Element e, SelectorPart selpart)
     {
-        if (selpart instanceof PseudoPage)
+        if (selpart instanceof PseudoClass)
         {
-            PseudoDeclaration required = ((PseudoPage) selpart).getDeclaration();
+            PseudoClassType required = ((PseudoClass) selpart).getType();
             
             if (elements != null)
             {
-                Set<PseudoDeclaration> pseudos = elements.get(e);
+                Set<PseudoClassType> pseudos = elements.get(e);
                 if (pseudos != null)
                     return pseudos.contains(required);
             }
             
             if (names != null)
             {
-                Set<PseudoDeclaration> pseudos = names.get(e.getTagName().toLowerCase());
+                Set<PseudoClassType> pseudos = names.get(e.getTagName().toLowerCase());
                 if (pseudos != null)
                     return pseudos.contains(required);
             }
@@ -158,16 +158,16 @@ public class MatchConditionOnElements implements MatchCondition
     public Object clone() {
     	final MatchConditionOnElements clone = new MatchConditionOnElements();
     	if (elements != null) {
-    		clone.elements = new HashMap<Element, Set<PseudoDeclaration>>();
+    		clone.elements = new HashMap<Element, Set<PseudoClassType>>();
     		for (final Element e : elements.keySet()) {
-                final HashSet<PseudoDeclaration> clonedDeclarations = new HashSet<PseudoDeclaration>(elements.get(e));
+                final HashSet<PseudoClassType> clonedDeclarations = new HashSet<PseudoClassType>(elements.get(e));
     			clone.elements.put(e, clonedDeclarations);
     		}
     	}
     	if (names != null) {
-    		clone.names = new HashMap<String, Set<PseudoDeclaration>>();
+    		clone.names = new HashMap<String, Set<PseudoClassType>>();
 			for (final String n : names.keySet()) {
-                final HashSet<PseudoDeclaration> clonedDeclarations = new HashSet<PseudoDeclaration>(names.get(n));
+                final HashSet<PseudoClassType> clonedDeclarations = new HashSet<PseudoClassType>(names.get(n));
     			clone.names.put(n, clonedDeclarations);
     		}
     	}

--- a/src/main/java/cz/vutbr/web/csskit/OutputUtil.java
+++ b/src/main/java/cz/vutbr/web/csskit/OutputUtil.java
@@ -33,7 +33,7 @@ public class OutputUtil {
 	public static final String PROPERTY_CLOSING = ";\n";
 	public static final String IMPORTANT_KEYWORD = "!important";
 	public static final String PAGE_KEYWORD = "@page";
-	public static final String PAGE_OPENING = ":";
+	public static final String PSEUDO_OPENING = ":";
 	public static final String PAGE_CLOSING = "";
     public static final String VIEWPORT_KEYWORD = "@viewport";
     public static final String FONT_FACE_KEYWORD = "@font-face";

--- a/src/main/java/cz/vutbr/web/csskit/RuleFactoryImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/RuleFactoryImpl.java
@@ -149,12 +149,39 @@ public class RuleFactoryImpl implements RuleFactory {
 		return new SelectorImpl.ElementIDImpl(id);
 	}
 	
-	public PseudoPage createPseudoPage(String pseudo, String functionName, boolean isPseudoElement) {
-		return new SelectorImpl.PseudoPageImpl(pseudo, functionName, isPseudoElement);
-	}
-	
-    public PseudoPage createPseudoPage(Selector selector, String functionName) {
-        return new SelectorImpl.PseudoPageImpl(selector, functionName);
+    @Override
+    public Selector.PseudoPage createPseudoPage(String name) {
+        return new SelectorImpl.PseudoPageImpl(name);
+    }
+    
+    @Override
+    public Selector.PseudoElement createPseudoElement(String name) {
+        return new SelectorImpl.PseudoElementImpl(name);
+    }
+    
+    @Override
+    public Selector.PseudoElement createPseudoElement(String name, String functionValue) {
+        return new SelectorImpl.PseudoElementImpl(name, functionValue);
+    }
+    
+    @Override
+    public Selector.PseudoElement createPseudoElement(String name, Selector nestedSelector) {
+        return new SelectorImpl.PseudoElementImpl(name, nestedSelector);
+    }
+    
+	@Override
+    public Selector.PseudoClass createPseudoClass(String name) {
+        return new SelectorImpl.PseudoClassImpl(name);
+    }
+    
+    @Override
+    public Selector.PseudoClass createPseudoClass(String name, String functionValue) {
+        return new SelectorImpl.PseudoClassImpl(name, functionValue);
+    }
+    
+	@Override
+    public Selector.PseudoClass createPseudoClass(String name, Selector nestedSelector) {
+        return new SelectorImpl.PseudoClassImpl(name, nestedSelector);
     }
     
 	public StyleSheet createStyleSheet() {

--- a/src/main/java/cz/vutbr/web/csskit/RulePageImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/RulePageImpl.java
@@ -8,6 +8,7 @@ import cz.vutbr.web.css.PrettyOutput;
 import cz.vutbr.web.css.Rule;
 import cz.vutbr.web.css.RuleMargin;
 import cz.vutbr.web.css.RulePage;
+import cz.vutbr.web.css.Selector;
 
 /**
  * Wrap of declarations bounded with a page rule 
@@ -19,7 +20,7 @@ import cz.vutbr.web.css.RulePage;
 public class RulePageImpl extends AbstractRuleBlock<Rule<?>> implements RulePage {
 
 	protected String name;
-	protected String pseudo;
+	protected Selector.PseudoPage pseudo;
 	
 	protected RulePageImpl() {
 		super();
@@ -48,7 +49,7 @@ public class RulePageImpl extends AbstractRuleBlock<Rule<?>> implements RulePage
 	/**
 	 * Gets pseudo-class of the page
 	 */
-	public String getPseudo() {
+	public Selector.PseudoPage getPseudo() {
 		return pseudo;
 	}
 
@@ -57,7 +58,7 @@ public class RulePageImpl extends AbstractRuleBlock<Rule<?>> implements RulePage
 	 * @param pseudo The pseudo-class to set
 	 * @return Modified instance
 	 */
-	public RulePage setPseudo(String pseudo) {
+	public RulePage setPseudo(Selector.PseudoPage pseudo) {
 		this.pseudo = pseudo;
 		return this;
 	}
@@ -82,8 +83,8 @@ public class RulePageImpl extends AbstractRuleBlock<Rule<?>> implements RulePage
     	sb.append(OutputUtil.PAGE_KEYWORD);
     	if(name != null && !"".equals(name))
     		sb.append(OutputUtil.SPACE_DELIM).append(name);
-    	if(pseudo != null && !"".equals(pseudo))
-    		sb.append(OutputUtil.PAGE_OPENING).append(pseudo);
+    	if(pseudo != null)
+    		sb.append(pseudo.toString());
     	
     	// append declarations and margin rules
     	sb.append(OutputUtil.RULE_OPENING);

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -1,7 +1,7 @@
 package cz.vutbr.web.csskit;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import org.unbescape.css.CssEscape;
 import org.w3c.dom.Element;
@@ -28,7 +28,7 @@ import cz.vutbr.web.css.CombinedSelector.Specificity.Level;
 public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements Selector {
 
 	protected Combinator combinator;
-	protected PseudoDeclaration pseudoElement; //the pseudo element if defined (only a single pseudo element may be used in the selector)
+	protected PseudoElementType pseudoElementType; //the pseudo element if defined (only a single pseudo element may be used in the selector)
     
 	@Override
     public Rule<SelectorPart> replaceAll(List<SelectorPart> replacement)
@@ -70,11 +70,8 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 	 * Registers the pseudo element if the given selector part is a pseudo element.
 	 */
 	private void checkPseudoElement(SelectorPart item) {
-        if(item instanceof PseudoPage) {
-            final PseudoDeclaration ret = ((PseudoPage)item).getDeclaration();
-            if (ret != null && ret.isPseudoElement()) {
-                pseudoElement = ret;
-            }
+        if(item instanceof PseudoElement) {
+            pseudoElementType = ((PseudoElement) item).getType();
         }
 	}
 	
@@ -127,18 +124,16 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
     	return elementName;
     }
     
-    public PseudoDeclaration getPseudoElement() {
-        return pseudoElement;
+    @Override
+    public PseudoElementType getPseudoElementType() {
+        return pseudoElementType;
     }
     
-    public boolean hasPseudoDeclaration(final PseudoDeclaration pd) {
+    @Override
+    public boolean hasPseudoClass(final PseudoClassType pct) {
         for(SelectorPart item : list) {
-            if(item instanceof PseudoPage)
-            {
-                final PseudoDeclaration ret = ((PseudoPage)item).getDeclaration();
-                if (ret == pd) {
-                    return true;
-                }
+            if(item instanceof PseudoClass && ((PseudoClass) item).getType() == pct) {
+                return true;
             }
         }
         return false;
@@ -355,208 +350,272 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 		}    	
     }
     
-    /**
-     * Wrap of CSS pseudo class or pseudo class with function
-     * @author kapy
-     *
-     */
     public static class PseudoPageImpl implements PseudoPage {
-    	
-        private static final HashMap<String, PseudoDeclaration> PSEUDO_DECLARATIONS;
-        static {
-            PSEUDO_DECLARATIONS = new HashMap<>(PseudoDeclaration.values().length);
+
+        private final String name;
+        private final PseudoPageType type;
+        
+        protected PseudoPageImpl(String name) {
+            this.name = name;
+            type = PseudoPageType.forName(name);
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public PseudoPageType getType() {
+            return type;
+        }
+
+        @Override
+        public void computeSpecificity(Specificity spec) {
+            spec.add(Level.C);
+        }
+        
+        @Override
+        public boolean matches(Element e, ElementMatcher matcher, MatchCondition cond) {
+            // TODO: check this implementation
+            if (type == null) {
+                return false; // unknown or unimplemented pseudo
+            }
+            return cond.isSatisfied(e, this);
+        }
+        
+        @Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append(OutputUtil.PSEUDO_OPENING);
+			
+			if(name!=null) 
+				sb.append(name);
+			
+			return sb.toString();
+		}
+
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 23 * hash + Objects.hashCode(this.name);
+            hash = 23 * hash + Objects.hashCode(this.type);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final PseudoPageImpl other = (PseudoPageImpl) obj;
+            if (!Objects.equals(this.name, other.name)) {
+                return false;
+            }
+            if (this.type != other.type) {
+                return false;
+            }
+            return true;
+        }
+        
+    }
+    
+    public static class PseudoClassImpl implements PseudoClass {
+
+        private final String name;
+        private final String functionValue;
+        private final PseudoClassType type;
+        private Selector nestedSelector; // for :not(sel)
+    	private int[] elementIndex; // decoded element index for nth-XXXX properties -- values a and b in the an+b specification
+        
+        private PseudoClassImpl(String name, String functionValue, Selector nestedSelector) {
+            this.name = name;
+            type = PseudoClassType.forName(name);
+            this.functionValue = functionValue;
+            this.nestedSelector = nestedSelector;
             
-            for (PseudoDeclaration declaration : PseudoDeclaration.values()) {
-                if (declaration.value() == null) {
-                    continue;
+            // Type-specific initialization
+            if (type != null) {
+                switch (type) {
+                    case NOT:
+                        if (nestedSelector == null && functionValue != null) {
+                            nestedSelector = new SelectorImpl();
+                            nestedSelector.add(new ElementNameImpl(functionValue));
+                        }
+                        break;
+                    case NTH_CHILD:
+                    case NTH_LAST_CHILD:
+                    case NTH_OF_TYPE:
+                    case NTH_LAST_OF_TYPE:
+                        elementIndex = decodeIndex(functionValue);
+                        break;
                 }
-                
-                PSEUDO_DECLARATIONS.put(declaration.value(), declaration);
             }
         }
         
-    	private String functionName;
-    	private String value;
-    	private PseudoDeclaration declaration;
-    	private Selector selector; //nested selector (for :not(sel))
-    	//decoded element index for nth-XXXX properties -- values a and b in the an+b specification
-    	private int[] elementIndex;
-    	
-    	protected PseudoPageImpl(String value, String functionName, boolean isPseudoElement) {
-            this.value = value;
-            this.functionName = functionName;
-            inferDeclaration(isPseudoElement);
-            decodeValue();
-    	}
-
-        protected PseudoPageImpl(Selector selector, String functionName) {
-            this.value = null;
-            this.functionName = functionName;
-            this.selector = selector;
-            inferDeclaration(false);
-            decodeValue();
+        protected PseudoClassImpl(String name) {
+            this(name, null, null);
         }
-    	
-    	public PseudoDeclaration getDeclaration()
-    	{
-    	    return declaration;
-    	}
-    	
-		/**
-		 * @return the functionName
-		 */
-		public String getFunctionName() {
-			return functionName;
-		}
-
-		/**
-		 * @param functionName the functionName to set
-		 */
-		public PseudoPage setFunctionName(String functionName) {			
-			this.functionName = functionName;
-            inferDeclaration(false);
-            decodeValue();
-			return this;
-		}
-		
-		public Selector getSelector() {
-            return selector;
+        
+        protected PseudoClassImpl(String name, String functionValue) {
+            this(name, functionValue, null);
+        }
+        
+        protected PseudoClassImpl(String name, Selector nestedSelector) {
+            this(name, null, nestedSelector);
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+        
+        @Override
+        public String getFunctionValue() {
+            return functionValue;
         }
 
-        public void setSelector(Selector selector) {
-            this.selector = selector;
+        @Override
+        public PseudoClassType getType() {
+            return type;
         }
 
+        @Override
+        public Selector getNestedSelector() {
+            return nestedSelector;
+        }
+
+        @Override
         public void computeSpecificity(Specificity spec) {
-
-		    if (declaration != null)
-		    {
-    			if(declaration.isPseudoElement())
-    				spec.add(Level.D);
-    			else
-    				spec.add(Level.C);
-		    }
-
-		}		
-		
-		public boolean matches(Element e, ElementMatcher matcher, MatchCondition cond) {
-			
-			if(declaration != null) { //null declaration means some unknown or unimplemented pseudo
-				switch (declaration) {
-					case FIRST_CHILD:
-					case LAST_CHILD:
-					case ONLY_CHILD:
-					    if (e.getParentNode().getNodeType() == Node.ELEMENT_NODE)
-					    {
-    						boolean first = false;
-    						boolean last = false;
-    						if (declaration != PseudoDeclaration.LAST_CHILD) {
-    							Node prev = e;
-    							do {
-    								prev = prev.getPreviousSibling();
-    								if (prev == null) {
-    								    first = true;
-    								    break;
-    								}
-    							} while(prev.getNodeType() != Node.ELEMENT_NODE);
-    						}
-    						if (declaration != PseudoDeclaration.FIRST_CHILD) {
-    							Node next = e;
-    							do {
-    								next = next.getNextSibling();
-    								if (next == null) {
-    								    last = true;
-    								    break; 
-    								}
-    							} while(next.getNodeType() != Node.ELEMENT_NODE);
-    						}
-    						switch (declaration) {
-    							case FIRST_CHILD: return first;
-    							case LAST_CHILD: return last;
-    							default: return first && last; //ONLY_CHILD
-    						}
-					    }
-					    else
-					        return false;
-                    case FIRST_OF_TYPE:
-                    case LAST_OF_TYPE:
-                    case ONLY_OF_TYPE:
-                        if (e.getParentNode().getNodeType() == Node.ELEMENT_NODE)
-                        {
-                            boolean firstt = false;
-                            boolean lastt = false;
-                            if (declaration != PseudoDeclaration.LAST_OF_TYPE) {
-                                Node prev = e;
-                                firstt = true;
-                                do {
-                                    prev = prev.getPreviousSibling();
-                                    if (prev != null && prev.getNodeType() == Node.ELEMENT_NODE
-                                            && isSameElementType(e, (Element) prev))
-                                        firstt = false;
-                                } while (prev != null && firstt);
-                            }
-                            if (declaration != PseudoDeclaration.FIRST_OF_TYPE) {
-                                Node next = e;
-                                lastt = true;
-                                do {
-                                    next = next.getNextSibling();
-                                    if (next != null && next.getNodeType() == Node.ELEMENT_NODE
-                                            && isSameElementType(e, (Element) next))
-                                        lastt = false;
-                                } while(next != null && lastt);
-                            }
-                            switch (declaration) {
-                                case FIRST_OF_TYPE: return firstt;
-                                case LAST_OF_TYPE: return lastt;
-                                default: return firstt && lastt; //ONLY_OF_TYPE
-                            }
+            spec.add(Level.C);
+        }
+        
+        @Override
+        public boolean matches(Element e, ElementMatcher matcher, MatchCondition cond) {
+            if (type == null) {
+                return false; // unknown or unimplemented pseudo
+            }
+            
+            switch (type) {
+                case FIRST_CHILD:
+                case LAST_CHILD:
+                case ONLY_CHILD:
+                    if (e.getParentNode().getNodeType() == Node.ELEMENT_NODE)
+                    {
+                        boolean first = false;
+                        boolean last = false;
+                        if (type != PseudoClassType.LAST_CHILD) {
+                            Node prev = e;
+                            do {
+                                prev = prev.getPreviousSibling();
+                                if (prev == null) {
+                                    first = true;
+                                    break;
+                                }
+                            } while(prev.getNodeType() != Node.ELEMENT_NODE);
                         }
-                        else
+                        if (type != PseudoClassType.FIRST_CHILD) {
+                            Node next = e;
+                            do {
+                                next = next.getNextSibling();
+                                if (next == null) {
+                                    last = true;
+                                    break; 
+                                }
+                            } while(next.getNodeType() != Node.ELEMENT_NODE);
+                        }
+                        switch (type) {
+                            case FIRST_CHILD: return first;
+                            case LAST_CHILD: return last;
+                            default: return first && last; //ONLY_CHILD
+                        }
+                    }
+                    else
+                        return false;
+                case FIRST_OF_TYPE:
+                case LAST_OF_TYPE:
+                case ONLY_OF_TYPE:
+                    if (e.getParentNode().getNodeType() == Node.ELEMENT_NODE)
+                    {
+                        boolean firstt = false;
+                        boolean lastt = false;
+                        if (type != PseudoClassType.LAST_OF_TYPE) {
+                            Node prev = e;
+                            firstt = true;
+                            do {
+                                prev = prev.getPreviousSibling();
+                                if (prev != null && prev.getNodeType() == Node.ELEMENT_NODE
+                                        && isSameElementType(e, (Element) prev))
+                                    firstt = false;
+                            } while (prev != null && firstt);
+                        }
+                        if (type != PseudoClassType.FIRST_OF_TYPE) {
+                            Node next = e;
+                            lastt = true;
+                            do {
+                                next = next.getNextSibling();
+                                if (next != null && next.getNodeType() == Node.ELEMENT_NODE
+                                        && isSameElementType(e, (Element) next))
+                                    lastt = false;
+                            } while(next != null && lastt);
+                        }
+                        switch (type) {
+                            case FIRST_OF_TYPE: return firstt;
+                            case LAST_OF_TYPE: return lastt;
+                            default: return firstt && lastt; //ONLY_OF_TYPE
+                        }
+                    }
+                    else
+                        return false;
+                case NTH_CHILD:
+                    return positionMatches(countSiblingsBefore(e, false) + 1, elementIndex);
+                case NTH_LAST_CHILD:
+                    return positionMatches(countSiblingsAfter(e, false) + 1, elementIndex);
+                case NTH_OF_TYPE:
+                    return positionMatches(countSiblingsBefore(e, true) + 1, elementIndex);
+                case NTH_LAST_OF_TYPE:
+                    return positionMatches(countSiblingsAfter(e, true) + 1, elementIndex);
+                case ROOT:
+                    return e.getParentNode().getNodeType() == Node.DOCUMENT_NODE;
+                case EMPTY:
+                    NodeList elist = e.getChildNodes();
+                    for (int i = 0; i < elist.getLength(); i++)
+                    {
+                        short t = elist.item(i).getNodeType();
+                        if (t == Node.ELEMENT_NODE || t == Node.TEXT_NODE 
+                                ||t == Node.CDATA_SECTION_NODE || t == Node.ENTITY_REFERENCE_NODE)
                             return false;
-                    case NTH_CHILD:
-                        return positionMatches(countSiblingsBefore(e, false) + 1, elementIndex);
-                    case NTH_LAST_CHILD:
-                        return positionMatches(countSiblingsAfter(e, false) + 1, elementIndex);
-                    case NTH_OF_TYPE:
-                        return positionMatches(countSiblingsBefore(e, true) + 1, elementIndex);
-                    case NTH_LAST_OF_TYPE:
-                        return positionMatches(countSiblingsAfter(e, true) + 1, elementIndex);
-                    case ROOT:
-                        return e.getParentNode().getNodeType() == Node.DOCUMENT_NODE;
-                    case EMPTY:
-                        NodeList elist = e.getChildNodes();
-                        for (int i = 0; i < elist.getLength(); i++)
-                        {
-                            short t = elist.item(i).getNodeType();
-                            if (t == Node.ELEMENT_NODE || t == Node.TEXT_NODE 
-                                    ||t == Node.CDATA_SECTION_NODE || t == Node.ENTITY_REFERENCE_NODE)
-                                return false;
-                        }
-                        return true;
-                    case NOT:
-                        if (selector != null) {
-                            return !selector.matches(e, matcher, cond);
-                        } else if (value != null) {
-                            final ElementName sel = new ElementNameImpl(value);
-                            return !sel.matches(e, matcher, cond);
-                        }
-                        else
-                            return false;
-					default:
-					    //match all pseudo elements and the pseudo classes specified by an additional condition (usually used for using LINK pseudo class for links)
-						if (declaration.isPseudoElement() || cond.isSatisfied(e, this)) 
-						{
-							return true;
-						}
-				}
-			}
-			return false;
+                    }
+                    return true;
+                case NOT:
+                    return nestedSelector != null && !nestedSelector.matches(e, matcher, cond);
+                default:
+                    // match all pseudo classes specified by an additional condition (usually used for using LINK pseudo class for links)
+                    return cond.isSatisfied(e, this);
+            }
+        }
+
+        /**
+		 * Checks whether two elements have the same name.
+		 * @param e1 the first element
+		 * @param e2 the second element
+		 * @return <code>true</code> when the elements have the same names
+		 */
+		protected boolean isSameElementType(Element e1, Element e2)
+		{
+		    return e1.getNodeName().equalsIgnoreCase(e2.getNodeName());
 		}
-		
-		/**
+        
+        /**
 		 * Checks whether the element position matches a <code>an+b</code> index specification.
 		 * @param pos The element position according to some counting criteria.
-		 * @param n The index specifiaction <code>an+b</code> - <code>a</code> and <code>b</code> values in array int[2].
+		 * @param n The index specification <code>an+b</code> - <code>a</code> and <code>b</code> values in array int[2].
 		 * @return <code>true</code> when the position matches the index.
 		 */
 		protected boolean positionMatches(int pos, int[] n)
@@ -576,57 +635,8 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 		    else //no indices specified (syntax error or missing values)
 		        return false;
 		}
-		
-		/**
-		 * Decodes the element index in the <code>an+b</code> form.
-		 * @param index the element index string
-		 * @return an array of two integers <code>a</code> and <code>b</code>
-		 * @throws NumberFormatException
-		 */
-		protected int[] decodeIndex(String index) throws NumberFormatException
-		{
-		    String s = index.toLowerCase().trim();
-		    if (s.equals("odd")){
-                int[] ret = {2, 1};
-                return ret;
-		    }
-		    else if (s.equals("even")){
-                int[] ret = {2, 0};
-                return ret;
-            }
-		    else {
-                int[] ret = {0, 0};
-    		    int n = s.indexOf('n');
-    		    if (n != -1)
-    		    {
-    		        String sa = s.substring(0, n).trim();
-                    if (sa.length() == 0)
-                        ret[0] = 1;
-                    else if (sa.equals("-"))
-                        ret[0] = -1;
-                    else
-                        ret[0] = Integer.parseInt(sa);
-                    
-    		        n++;
-    		        StringBuilder sb = new StringBuilder();
-    		        while (n < s.length())
-    		        {
-    		            char ch = s.charAt(n);
-    		            if (ch != '+' && !Character.isWhitespace(ch))
-    		                sb.append(ch);
-    		            n++;
-    		        }
-    		        if (sb.length() > 0)
-    	                ret[1] = Integer.parseInt(sb.toString());
-    		    }
-    		    else
-    		        ret[1] = Integer.parseInt(s);
-    		    
-    		    return ret;
-		    }
-		}
-		
-		/**
+        
+        /**
 		 * Computes the count of element siblings before the given element in the DOM tree.
 		 * @param e The element to be examined
 		 * @param sameType when set to <code>true</code> only the element with the same type are considered.
@@ -672,119 +682,235 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             return cnt;
         }
         
-		/**
-		 * Checks whether two elements have the same name.
-		 * @param e1 the first element
-		 * @param e2 the second element
-		 * @return <code>true</code> when the elements have the same names
+        /**
+		 * Decodes the element index in the <code>an+b</code> form.
+		 * @param index the element index string
+		 * @return an array of two integers <code>a</code> and <code>b</code>, or null if the index string is malformatted
 		 */
-		protected boolean isSameElementType(Element e1, Element e2)
+		protected int[] decodeIndex(String index)
 		{
-		    return e1.getNodeName().equalsIgnoreCase(e2.getNodeName());
+            if (index == null) {
+                return null;
+            }
+		    String s = index.toLowerCase().trim();
+		    if (s.equals("odd")){
+                return new int[] {2, 1};
+		    }
+		    if (s.equals("even")){
+                return new int[] {2, 0};
+            }
+		    try {
+                int[] ret = {0, 0};
+    		    int n = s.indexOf('n');
+    		    if (n != -1)
+    		    {
+    		        String sa = s.substring(0, n).trim();
+                    if (sa.length() == 0)
+                        ret[0] = 1;
+                    else if (sa.equals("-"))
+                        ret[0] = -1;
+                    else
+                        ret[0] = Integer.parseInt(sa);
+                    
+    		        n++;
+    		        StringBuilder sb = new StringBuilder();
+    		        while (n < s.length())
+    		        {
+    		            char ch = s.charAt(n);
+    		            if (ch != '+' && !Character.isWhitespace(ch))
+    		                sb.append(ch);
+    		            n++;
+    		        }
+    		        if (sb.length() > 0)
+    	                ret[1] = Integer.parseInt(sb.toString());
+    		    }
+    		    else
+    		        ret[1] = Integer.parseInt(s);
+    		    
+    		    return ret;
+            } catch (NumberFormatException nfe) {
+                return null;
+            }
 		}
-		
-		/**
-		 * Sets value of pseudo. Could be even <code>null</code>
-		 * @param value New value
-		 */
-		public PseudoPage setValue(String value, boolean isPseudoElement) {
-			this.value = value;
-			inferDeclaration(isPseudoElement);
-			decodeValue();
-			return this;
-		}
-		
-
-		public String getValue() {
-			return value;
-		}
-				
-		@Override
+        
+        @Override
 		public String toString() {
 			StringBuilder sb = new StringBuilder();
-			 
 			sb.append(OutputUtil.PSEUDO_OPENING);
-			if (declaration!=null && declaration.isPseudoElement())
-	            sb.append(OutputUtil.PSEUDO_OPENING);
 			
-			if(functionName!=null) 
-				sb.append(functionName).append(OutputUtil.FUNCTION_OPENING);
-			if(selector != null)
-			    sb.append(selector.toString());
-			else if(value!=null)
-			    sb.append(CssEscape.escapeCssIdentifier(value));
-			if(functionName!=null)
-				sb.append(OutputUtil.FUNCTION_CLOSING);
+			if(name!=null) 
+				sb.append(name);
+            
+			if(nestedSelector != null)
+			    sb.append(OutputUtil.FUNCTION_OPENING).append(nestedSelector.toString()).append(OutputUtil.FUNCTION_CLOSING);
+			else if(functionValue != null)
+			    sb.append(OutputUtil.FUNCTION_OPENING).append(CssEscape.escapeCssIdentifier(functionValue)).append(OutputUtil.FUNCTION_CLOSING);
 			
-			sb.append(OutputUtil.PAGE_CLOSING);
+			return sb.toString();
+		}
+        
+        @Override
+        public int hashCode() {
+            int hash = 17;
+            hash = 43 * hash + Objects.hashCode(this.name);
+            hash = 43 * hash + Objects.hashCode(this.functionValue);
+            hash = 43 * hash + Objects.hashCode(this.type);
+            hash = 43 * hash + Objects.hashCode(this.nestedSelector);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final PseudoClassImpl other = (PseudoClassImpl) obj;
+            if (this.type != other.type) {
+                return false;
+            }
+            if (!Objects.equals(this.name, other.name)) {
+                return false;
+            }
+            if (!Objects.equals(this.functionValue, other.functionValue)) {
+                return false;
+            }
+            if (!Objects.equals(this.nestedSelector, other.nestedSelector)) {
+                return false;
+            }
+            return true;
+        }
+    }
+    
+    public static class PseudoElementImpl implements PseudoElement {
+
+        private final String name;
+        private final String functionValue;
+        private final PseudoElementType type;
+        private Selector nestedSelector; // for ::cue(sel)
+        
+        private PseudoElementImpl(String name, String functionValue, Selector nestedSelector) {
+            this.name = name;
+            type = PseudoElementType.forName(name);
+            this.functionValue = functionValue;
+            this.nestedSelector = nestedSelector;
+            
+            // Type-specific initialization
+            if (type != null) {
+                switch (type) {
+                    case CUE:
+                        if (nestedSelector == null && functionValue != null) {
+                            nestedSelector = new SelectorImpl();
+                            nestedSelector.add(new ElementNameImpl(functionValue));
+                        }
+                        break;
+                }
+            }
+        }
+        
+        protected PseudoElementImpl(String name) {
+            this(name, null, null);
+        }
+        
+        protected PseudoElementImpl(String name, String functionValue) {
+            this(name, functionValue, null);
+        }
+        
+        protected PseudoElementImpl(String name, Selector nestedSelector) {
+            this(name, null, nestedSelector);
+        }
+        
+        @Override
+        public String getName() {
+            return name;
+        }
+        
+        @Override
+        public String getFunctionValue() {
+            return functionValue;
+        }
+
+        @Override
+        public PseudoElementType getType() {
+            return type;
+        }
+
+        @Override
+        public Selector getNestedSelector() {
+            return nestedSelector;
+        }
+
+        @Override
+        public void computeSpecificity(Specificity spec) {
+            spec.add(Level.D);
+        }
+        
+        @Override
+        public boolean matches(Element e, ElementMatcher matcher, MatchCondition cond) {
+            // TODO: check
+            if (type == null) {
+                return false; // Unknown or unimplemented pseudo-element
+            }
+            return true; // All pseudo-elements match
+        }
+        
+        @Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append(OutputUtil.PSEUDO_OPENING).append(OutputUtil.PSEUDO_OPENING);
+			
+			if(name!=null) 
+				sb.append(name);
+            
+			if(nestedSelector != null)
+			    sb.append(OutputUtil.FUNCTION_OPENING).append(nestedSelector.toString()).append(OutputUtil.FUNCTION_CLOSING);
+			else if(functionValue != null)
+			    sb.append(OutputUtil.FUNCTION_OPENING).append(CssEscape.escapeCssIdentifier(functionValue)).append(OutputUtil.FUNCTION_CLOSING);
 			
 			return sb.toString();
 		}
 
-		/* (non-Javadoc)
-		 * @see java.lang.Object#hashCode()
-		 */
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result
-					+ ((functionName == null) ? 0 : functionName.hashCode());
-			result = prime * result + ((value == null) ? 0 : value.hashCode());
-			return result;
-		}
-
-		/* (non-Javadoc)
-		 * @see java.lang.Object#equals(java.lang.Object)
-		 */
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (!(obj instanceof PseudoPageImpl))
-				return false;
-			PseudoPageImpl other = (PseudoPageImpl) obj;
-			if (functionName == null) {
-				if (other.functionName != null)
-					return false;
-			} else if (!functionName.equals(other.functionName))
-				return false;
-			if (value == null) {
-				if (other.value != null)
-					return false;
-			} else if (!value.equals(other.value))
-				return false;
-			return true;
-		}
-		
-		private void inferDeclaration(boolean isPseudoElement)
-		{
-		    if (functionName != null)
-		        declaration = PSEUDO_DECLARATIONS.get(functionName.toLowerCase()); //Pseudo-element and pseudo-class names are case-insensitive
-		    else if (value != null && value.startsWith("-")) // Vendor-specific
-                declaration = (isPseudoElement ? PseudoDeclaration.vendor_element : PseudoDeclaration.vendor_class);
-            else if (value != null)
-		        declaration = PSEUDO_DECLARATIONS.get(value.toLowerCase());
-            else
-		        declaration = null;
-		}
-
-        private void decodeValue()
-        {
-            //decode the element index for nth-X properties
-            elementIndex = null;
-            if (declaration == PseudoDeclaration.NTH_CHILD || declaration == PseudoDeclaration.NTH_LAST_CHILD
-                    || declaration == PseudoDeclaration.NTH_OF_TYPE || declaration == PseudoDeclaration.NTH_LAST_OF_TYPE)
-            {
-                try {
-                    elementIndex = decodeIndex(value);
-                } catch (NumberFormatException e) {
-                }
-            }
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 53 * hash + Objects.hashCode(this.name);
+            hash = 53 * hash + Objects.hashCode(this.functionValue);
+            hash = 53 * hash + Objects.hashCode(this.type);
+            hash = 53 * hash + Objects.hashCode(this.nestedSelector);
+            return hash;
         }
 
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final PseudoElementImpl other = (PseudoElementImpl) obj;
+            if (this.type != other.type) {
+                return false;
+            }
+            if (!Objects.equals(this.name, other.name)) {
+                return false;
+            }
+            if (!Objects.equals(this.functionValue, other.functionValue)) {
+                return false;
+            }
+            if (!Objects.equals(this.nestedSelector, other.nestedSelector)) {
+                return false;
+            }
+            return true;
+        }
     }
     
     /**

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -703,9 +703,9 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 		public String toString() {
 			StringBuilder sb = new StringBuilder();
 			 
-			sb.append(OutputUtil.PAGE_OPENING);
+			sb.append(OutputUtil.PSEUDO_OPENING);
 			if (declaration!=null && declaration.isPseudoElement())
-	            sb.append(OutputUtil.PAGE_OPENING);
+	            sb.append(OutputUtil.PSEUDO_OPENING);
 			
 			if(functionName!=null) 
 				sb.append(functionName).append(OutputUtil.FUNCTION_OPENING);

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/Preparator.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/Preparator.java
@@ -40,7 +40,7 @@ public interface Preparator {
 	 * @return RuleSet
 	 */
 	public RuleBlock<?> prepareInlineRuleSet(List<Declaration> dlist,
-			List<Selector.PseudoPage> pseudos);
+			List<Selector.SelectorPart> pseudos);
 	
 	/**
 	 * Creates RuleMedia, block of rules with assigned medias. Uses mark to change priority of rules,

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/Preparator.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/Preparator.java
@@ -59,7 +59,7 @@ public interface Preparator {
      * @param pseudo Pseudo-class of the page
 	 * @return RulePage
 	 */
-	public RuleBlock<?> prepareRulePage(List<Declaration> declarations, List<RuleMargin> marginRules, String name, String pseudo);
+	public RuleBlock<?> prepareRulePage(List<Declaration> declarations, List<RuleMargin> marginRules, String name, Selector.PseudoPage pseudo);
 	
     /**
      * Creates RuleMargin, block of declarations associated with specific area in the page margin. 

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/SimplePreparator.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/SimplePreparator.java
@@ -96,14 +96,6 @@ public class SimplePreparator implements Preparator {
 			log.debug("Empty RulePage was ommited");
 			return null;
 		}
-        if (pseudo != null && 
-                pseudo.getDeclaration() != Selector.PseudoDeclaration.LEFT &&
-                pseudo.getDeclaration() != Selector.PseudoDeclaration.RIGHT &&
-                pseudo.getDeclaration() != Selector.PseudoDeclaration.FIRST &&
-                pseudo.getDeclaration() != Selector.PseudoDeclaration.BLANK) {
-            log.debug("Ommitting RulePage with invalid pseudo");
-			return null;
-        }
 
 		RulePage rp = rf.createPage();
         if (declarations != null)
@@ -164,8 +156,9 @@ public class SimplePreparator implements Preparator {
         return (RuleBlock<?>) rp;
     }
 
+    @Override
 	public RuleBlock<?> prepareInlineRuleSet(List<Declaration> dlist,
-			List<PseudoPage> pseudos) {
+			List<Selector.SelectorPart> pseudos) {
 
 		if(dlist==null || dlist.isEmpty()) {
 			log.debug("Empty RuleSet (inline) was ommited");
@@ -184,7 +177,7 @@ public class SimplePreparator implements Preparator {
 		rs.replaceAll(dlist);
 		rs.setSelectors(Arrays.asList(cs));
 		
-		log.info("Create @media as with:\n{}", rs);
+		log.info("Create inline ruleset as with:\n{}", rs);
 		
 		return (RuleBlock<?>) rs;
 	}

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/SimplePreparator.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/SimplePreparator.java
@@ -88,13 +88,22 @@ public class SimplePreparator implements Preparator {
 		return (RuleBlock<?>) rm;
 	}
 
-	public RuleBlock<?> prepareRulePage(List<Declaration> declarations, List<RuleMargin> marginRules, String name, String pseudo) {
+    @Override
+	public RuleBlock<?> prepareRulePage(List<Declaration> declarations, List<RuleMargin> marginRules, String name, Selector.PseudoPage pseudo) {
 
 	    if ((declarations == null || declarations.isEmpty()) &&
 	         (marginRules == null || marginRules.isEmpty())) {
 			log.debug("Empty RulePage was ommited");
 			return null;
 		}
+        if (pseudo != null && 
+                pseudo.getDeclaration() != Selector.PseudoDeclaration.LEFT &&
+                pseudo.getDeclaration() != Selector.PseudoDeclaration.RIGHT &&
+                pseudo.getDeclaration() != Selector.PseudoDeclaration.FIRST &&
+                pseudo.getDeclaration() != Selector.PseudoDeclaration.BLANK) {
+            log.debug("Ommitting RulePage with invalid pseudo");
+			return null;
+        }
 
 		RulePage rp = rf.createPage();
         if (declarations != null)

--- a/src/main/java/cz/vutbr/web/domassign/Analyzer.java
+++ b/src/main/java/cz/vutbr/web/domassign/Analyzer.java
@@ -25,7 +25,8 @@ import cz.vutbr.web.css.MediaSpec;
 import cz.vutbr.web.css.NodeData;
 import cz.vutbr.web.css.RuleSet;
 import cz.vutbr.web.css.Selector;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.Selector.PseudoElement;
+import cz.vutbr.web.css.Selector.PseudoElementType;
 import cz.vutbr.web.css.StyleSheet;
 
 /**
@@ -158,7 +159,7 @@ public class Analyzer {
 				result.put((Element) current, null, main.concretize());
 				
 				//repeat for the pseudo classes (if any)
-				for (PseudoDeclaration pseudo : ((DeclarationMap) source).pseudoSet((Element) current))
+				for (PseudoElementType pseudo : ((DeclarationMap) source).pseudoSet((Element) current))
 				{
 				    NodeData pdata = CSSFactory.createNodeData();
 	                declarations = ((DeclarationMap) source).get((Element) current, pseudo);
@@ -294,7 +295,7 @@ public class Analyzer {
 		List<Declaration> eldecl = new ArrayList<Declaration>();
 		
 		// existing pseudo selectors found
-		Set<PseudoDeclaration> pseudos = new HashSet<PseudoDeclaration>();
+		Set<PseudoElementType> pseudos = new HashSet<>();
 
 		// for all candidates
 		for (OrderedRule orule : clist) {
@@ -315,7 +316,7 @@ public class Analyzer {
 
 				log.trace("CombinedSelector \"{}\" matched", s);
 				
-				PseudoDeclaration pseudo = s.getPseudoElement();
+				PseudoElementType pseudo = s.getPseudoElementType();
                 CombinedSelector.Specificity spec = s.computeSpecificity();
 				if (pseudo == null)
 				{
@@ -339,7 +340,7 @@ public class Analyzer {
 		Collections.sort(eldecl); //sort the main list
 		log.debug("Sorted {} declarations.", eldecl.size());
 		log.trace("With values: {}", eldecl);
-		for (PseudoDeclaration p : pseudos)
+		for (PseudoElementType p : pseudos)
 		    declarations.sortDeclarations(e, p); //sort pseudos
 		
 		// set the main list

--- a/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
+++ b/src/main/java/cz/vutbr/web/domassign/AnalyzerUtil.java
@@ -24,7 +24,9 @@ import cz.vutbr.web.css.Rule;
 import cz.vutbr.web.css.RuleMedia;
 import cz.vutbr.web.css.RuleSet;
 import cz.vutbr.web.css.Selector;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.Selector.PseudoClassType;
+import cz.vutbr.web.css.Selector.PseudoElement;
+import cz.vutbr.web.css.Selector.PseudoElementType;
 import cz.vutbr.web.css.StyleSheet;
 import cz.vutbr.web.domassign.Analyzer.Holder;
 import cz.vutbr.web.domassign.Analyzer.HolderItem;
@@ -60,7 +62,7 @@ public final class AnalyzerUtil {
 	    return rules;
     }
 
-    public static NodeData getElementStyle(Element el, PseudoDeclaration pseudo, final ElementMatcher matcher, MatchCondition matchCond, OrderedRule[] applicableRules)
+    public static NodeData getElementStyle(Element el, PseudoElementType pseudo, final ElementMatcher matcher, MatchCondition matchCond, OrderedRule[] applicableRules)
     {
     	return makeNodeData(computeDeclarations(el, pseudo, applicableRules, matcher, matchCond));
     }
@@ -157,7 +159,7 @@ public final class AnalyzerUtil {
         }
     }
     
-	static List<Declaration> computeDeclarations(final Element e, final PseudoDeclaration pseudo, final OrderedRule[] clist, final ElementMatcher matcher, final MatchCondition matchCond) {
+	static List<Declaration> computeDeclarations(final Element e, final PseudoElementType pseudo, final OrderedRule[] clist, final ElementMatcher matcher, final MatchCondition matchCond) {
 		// resulting list of declaration for this element with no pseudo-selectors (main list)(local cache)
         final List<Declaration> eldecl = new ArrayList<Declaration>();
         
@@ -178,11 +180,11 @@ public final class AnalyzerUtil {
 
                 log.trace("CombinedSelector \"{}\" matched", s);
                 
-                final PseudoDeclaration psel = s.getPseudoElement();
-                final CombinedSelector.Specificity spec = s.computeSpecificity();
-                if (psel == pseudo)
+                final PseudoElementType ptype = s.getPseudoElementType();
+                if (ptype == pseudo)
                 {
                     // add to the resulting list
+                    final CombinedSelector.Specificity spec = s.computeSpecificity();
                     for (final Declaration d : rule)
                         eldecl.add(new AssignedDeclaration(d, spec, origin));
                 }
@@ -197,12 +199,12 @@ public final class AnalyzerUtil {
         return eldecl;
 	}
     
-    public static boolean hasPseudoSelector(final OrderedRule[] rules, final Element e, final MatchCondition matchCond, PseudoDeclaration pd)
+    public static boolean hasPseudoSelector(final OrderedRule[] rules, final Element e, final MatchCondition matchCond, PseudoClassType pd)
     {
 		for (final OrderedRule rule : rules) {
 			for (final CombinedSelector cs : rule.getRule().getSelectors()) {
 				final Selector lastSelector = cs.get(cs.size() - 1);
-				if (lastSelector.hasPseudoDeclaration(pd)) {
+				if (lastSelector.hasPseudoClass(pd)) {
 					return true;
 				}
 			}
@@ -210,7 +212,7 @@ public final class AnalyzerUtil {
 		return false;
 	}
 
-    public static boolean hasPseudoSelectorForAncestor(final OrderedRule[] rules, final Element e, final Element targetAncestor, final ElementMatcher matcher, final MatchCondition matchCond, PseudoDeclaration pd)
+    public static boolean hasPseudoSelectorForAncestor(final OrderedRule[] rules, final Element e, final Element targetAncestor, final ElementMatcher matcher, final MatchCondition matchCond, PseudoClassType pd)
     {
 		for (final OrderedRule rule : rules) {
 			for (final CombinedSelector cs : rule.getRule().getSelectors()) {
@@ -222,7 +224,7 @@ public final class AnalyzerUtil {
 		return false;
     }
 
-    private static boolean hasPseudoSelectorForAncestor(final CombinedSelector sel, final Element e, final Element targetAncestor, final ElementMatcher matcher, final MatchCondition matchCond, PseudoDeclaration pd)
+    private static boolean hasPseudoSelectorForAncestor(final CombinedSelector sel, final Element e, final Element targetAncestor, final ElementMatcher matcher, final MatchCondition matchCond, PseudoClassType pd)
     {
         boolean retval = false;
         Selector.Combinator combinator = null;
@@ -295,7 +297,7 @@ public final class AnalyzerUtil {
             if (!retval) {
                 break;
             } else if (current == targetAncestor) {
-                return s.hasPseudoDeclaration(pd);
+                return s.hasPseudoClass(pd);
             }
         }
         return false;

--- a/src/main/java/cz/vutbr/web/domassign/DeclarationMap.java
+++ b/src/main/java/cz/vutbr/web/domassign/DeclarationMap.java
@@ -12,7 +12,7 @@ import java.util.List;
 import org.w3c.dom.Element;
 
 import cz.vutbr.web.css.Declaration;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.Selector.PseudoElementType;
 
 /**
  * This is a map that assigns a sorted list of declarations to each element 
@@ -20,7 +20,7 @@ import cz.vutbr.web.css.Selector.PseudoDeclaration;
  * 
  * @author burgetr
  */
-public class DeclarationMap extends MultiMap<Element, PseudoDeclaration, List<Declaration>>
+public class DeclarationMap extends MultiMap<Element, PseudoElementType, List<Declaration>>
 {
 
     /**
@@ -29,7 +29,7 @@ public class DeclarationMap extends MultiMap<Element, PseudoDeclaration, List<De
      * @param pseudo an optional pseudo-element or null
      * @param decl the new declaration
      */
-    public void addDeclaration(Element el, PseudoDeclaration pseudo, Declaration decl)
+    public void addDeclaration(Element el, PseudoElementType pseudo, Declaration decl)
     {
         List<Declaration> list = getOrCreate(el, pseudo);
         list.add(decl);
@@ -40,7 +40,7 @@ public class DeclarationMap extends MultiMap<Element, PseudoDeclaration, List<De
      * @param el the element to which the list is assigned
      * @param pseudo an optional pseudo-element or null
      */
-    public void sortDeclarations(Element el, PseudoDeclaration pseudo)
+    public void sortDeclarations(Element el, PseudoElementType pseudo)
     {
         List<Declaration> list = get(el, pseudo);
         if (list != null)

--- a/src/main/java/cz/vutbr/web/domassign/DirectAnalyzer.java
+++ b/src/main/java/cz/vutbr/web/domassign/DirectAnalyzer.java
@@ -13,7 +13,7 @@ import org.w3c.dom.Element;
 
 import cz.vutbr.web.css.MediaSpec;
 import cz.vutbr.web.css.NodeData;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.Selector.PseudoElementType;
 import cz.vutbr.web.css.StyleSheet;
 
 /**
@@ -54,7 +54,7 @@ public class DirectAnalyzer extends Analyzer
      * @param media Used media specification.
      * @return The relevant declarations from the registered style sheets.
      */
-    public NodeData getElementStyle(Element el, PseudoDeclaration pseudo, MediaSpec media)
+    public NodeData getElementStyle(Element el, PseudoElementType pseudo, MediaSpec media)
     {
         final OrderedRule[] applicableRules = AnalyzerUtil.getApplicableRules(sheets, el, media);
         return AnalyzerUtil.getElementStyle(el, pseudo, getElementMatcher(), getMatchCondition(), applicableRules);
@@ -67,7 +67,7 @@ public class DirectAnalyzer extends Analyzer
      * @param media Used media name (e.g. "screen" or "all")
      * @return The relevant declarations from the registered style sheets.
      */
-    public NodeData getElementStyle(Element el, PseudoDeclaration pseudo, String media)
+    public NodeData getElementStyle(Element el, PseudoElementType pseudo, String media)
     {
         return getElementStyle(el, pseudo, new MediaSpec(media));
     }

--- a/src/main/java/cz/vutbr/web/domassign/StyleMap.java
+++ b/src/main/java/cz/vutbr/web/domassign/StyleMap.java
@@ -9,7 +9,7 @@ import org.w3c.dom.Element;
 
 import cz.vutbr.web.css.CSSFactory;
 import cz.vutbr.web.css.NodeData;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
+import cz.vutbr.web.css.Selector.PseudoElementType;
 
 /**
  * This is a map that assigns a style to a particular elements and moreover, it
@@ -17,7 +17,7 @@ import cz.vutbr.web.css.Selector.PseudoDeclaration;
  * 
  * @author burgetr
  */
-public class StyleMap extends MultiMap<Element, PseudoDeclaration, NodeData>
+public class StyleMap extends MultiMap<Element, PseudoElementType, NodeData>
 {
 
 	public StyleMap(int size)

--- a/src/test/java/test/ElementMatcherTest.java
+++ b/src/test/java/test/ElementMatcherTest.java
@@ -74,11 +74,11 @@ public class ElementMatcherTest {
         checkDocument(file, new ElementMatcherSafeCS(), exXHTML, "XHTML matcher safe/" + msg);
         checkDocument(file, new ElementMatcherSimpleCS(), exXHTML, "XHTML matcher simple/" + msg);
         
-        checkDocument(file, new ElementMatcherSafeStd(), exHTMLStd, "XHTML matcher safe/" + msg);
-        checkDocument(file, new ElementMatcherSimpleStd(), exHTMLStd, "XHTML matcher simple/" + msg);
+        checkDocument(file, new ElementMatcherSafeStd(), exHTMLStd, "HTMLstd matcher safe/" + msg);
+        checkDocument(file, new ElementMatcherSimpleStd(), exHTMLStd, "HTMLstd matcher simple/" + msg);
         
-        checkDocument(file, new ElementMatcherSafeCI(), exHTMLQuirks, "XHTML matcher safe/" + msg);
-        checkDocument(file, new ElementMatcherSimpleCI(), exHTMLQuirks, "XHTML matcher simple/" + msg);
+        checkDocument(file, new ElementMatcherSafeCI(), exHTMLQuirks, "HTMLquirks matcher safe/" + msg);
+        checkDocument(file, new ElementMatcherSimpleCI(), exHTMLQuirks, "HTMLquirks matcher simple/" + msg);
     }
     
     private void checkDocument(String name, ElementMatcher matcher, TermColor[] expect, String msg) throws SAXException, IOException

--- a/src/test/java/test/PageTest.java
+++ b/src/test/java/test/PageTest.java
@@ -51,7 +51,7 @@ public class PageTest {
         assertEquals("One rule is set", 1, ss.size());
         RulePage rule = (RulePage) ss.get(0);
         assertNotNull("Rule has a pseudo-class ", rule.getPseudo());
-        assertEquals("Rule has :left pseudo-class ", Selector.PseudoDeclaration.LEFT, rule.getPseudo().getDeclaration());
+        assertEquals("Rule has :left pseudo-class ", Selector.PseudoPageType.LEFT, rule.getPseudo().getType());
         assertEquals("Rule contains 1 declaration ", 1, rule.size());
     }
     
@@ -61,7 +61,7 @@ public class PageTest {
         assertEquals("One rule is set", 1, ss.size());
         RulePage rule = (RulePage) ss.get(0);
         assertNotNull("Rule has a pseudo-class ", rule.getPseudo());
-        assertEquals("Rule has :right pseudo-class ", Selector.PseudoDeclaration.RIGHT, rule.getPseudo().getDeclaration());
+        assertEquals("Rule has :right pseudo-class ", Selector.PseudoPageType.RIGHT, rule.getPseudo().getType());
         assertEquals("Rule contains 1 declaration ", 1, rule.size());
     }
     
@@ -71,7 +71,7 @@ public class PageTest {
         assertEquals("One rule is set", 1, ss.size());
         RulePage rule = (RulePage) ss.get(0);
         assertNotNull("Rule has a pseudo-class ", rule.getPseudo());
-        assertEquals("Rule has :first pseudo-class ", Selector.PseudoDeclaration.FIRST, rule.getPseudo().getDeclaration());
+        assertEquals("Rule has :first pseudo-class ", Selector.PseudoPageType.FIRST, rule.getPseudo().getType());
         assertEquals("Rule contains 1 declaration ", 1, rule.size());
     }
     

--- a/src/test/java/test/PageTest.java
+++ b/src/test/java/test/PageTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class PageTest {
     private static final Logger log = LoggerFactory.getLogger(PageTest.class);
@@ -21,11 +22,15 @@ public class PageTest {
                     "@top-left-corner { content: \" \"; border: solid green; }" +
                     "}";
 
+    public static final String TEST_STRING2 = "@page :left { margin: 1cm; }";
+    public static final String TEST_STRING3 = "@page :right { margin: 2cm; }";
+    public static final String TEST_STRING4 = "@page :first { margin: 3cm; }";
+    public static final String TEST_STRING5 = "@page :hover { margin: 4cm; }"; // Invalid
+    
     @BeforeClass
     public static void init() {
         log.info("\n\n\n == PageTest test at {} == \n\n\n", new Date());
     }
-
 
     @Test
     public void testMarginRule() throws IOException, CSSException {
@@ -40,4 +45,39 @@ public class PageTest {
         assertEquals("Margin rule contains 2 declarations", 2, margin.size());
     }
 
+    @Test
+    public void testLeftPseudo() throws IOException, CSSException {
+        StyleSheet ss = CSSFactory.parseString(TEST_STRING2, null);
+        assertEquals("One rule is set", 1, ss.size());
+        RulePage rule = (RulePage) ss.get(0);
+        assertNotNull("Rule has a pseudo-class ", rule.getPseudo());
+        assertEquals("Rule has :left pseudo-class ", Selector.PseudoDeclaration.LEFT, rule.getPseudo().getDeclaration());
+        assertEquals("Rule contains 1 declaration ", 1, rule.size());
+    }
+    
+    @Test
+    public void testRightPseudo() throws IOException, CSSException {
+        StyleSheet ss = CSSFactory.parseString(TEST_STRING3, null);
+        assertEquals("One rule is set", 1, ss.size());
+        RulePage rule = (RulePage) ss.get(0);
+        assertNotNull("Rule has a pseudo-class ", rule.getPseudo());
+        assertEquals("Rule has :right pseudo-class ", Selector.PseudoDeclaration.RIGHT, rule.getPseudo().getDeclaration());
+        assertEquals("Rule contains 1 declaration ", 1, rule.size());
+    }
+    
+    @Test
+    public void testFirstPseudo() throws IOException, CSSException {
+        StyleSheet ss = CSSFactory.parseString(TEST_STRING4, null);
+        assertEquals("One rule is set", 1, ss.size());
+        RulePage rule = (RulePage) ss.get(0);
+        assertNotNull("Rule has a pseudo-class ", rule.getPseudo());
+        assertEquals("Rule has :first pseudo-class ", Selector.PseudoDeclaration.FIRST, rule.getPseudo().getDeclaration());
+        assertEquals("Rule contains 1 declaration ", 1, rule.size());
+    }
+    
+    @Test
+    public void testInvalidPseudo() throws IOException, CSSException {
+        StyleSheet ss = CSSFactory.parseString(TEST_STRING5, null);
+        assertEquals("No rules are set", 0, ss.size());
+    }
 }

--- a/src/test/java/test/PseudoClassTest.java
+++ b/src/test/java/test/PseudoClassTest.java
@@ -159,6 +159,71 @@ public class PseudoClassTest {
         assertThat(nodeData.getValue(TermColor.class, "color"), is(tf.createColor(0,128,0)));
     }
 
+    private static final String TEST_PSEUDO_1 = // Legacy support
+            "p:first-line { color: red; }" +
+            "p:first-letter { color: blue; }" + 
+            "p:before { color: yellow; }" + 
+            "p:after { color: green; }";
+    private static final String TEST_PSEUDO_2 =
+            "p::first-line { color: red; }" +
+            "p::first-letter { color: blue; }" + 
+            "p::before { color: yellow; }" + 
+            "p::after { color: green; }";
+    
+    @Test
+    public void legacyPseudoElementSupport() throws CSSException, IOException {
+        StyleSheet style = CSSFactory.parseString(TEST_PSEUDO_1, null);
+        assertEquals("There are 4 rules", 4, style.size());
+        
+        List<CombinedSelector> sel1 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-line", null, true));
+        List<CombinedSelector> sel2 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-letter", null, true));
+        List<CombinedSelector> sel3 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("before", null, true));
+        List<CombinedSelector> sel4 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("after", null, true));
+
+        RuleSet rule1 = (RuleSet) style.get(0);
+        assertArrayEquals("Rule contains one selector p::first-line", sel1.toArray(), rule1.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule1.size());
+        
+        RuleSet rule2 = (RuleSet) style.get(1);
+        assertArrayEquals("Rule contains one selector p::first-letter", sel2.toArray(), rule2.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule2.size());
+        
+        RuleSet rule3 = (RuleSet) style.get(2);
+        assertArrayEquals("Rule contains one selector p::before", sel3.toArray(), rule3.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule3.size());
+        
+        RuleSet rule4 = (RuleSet) style.get(3);
+        assertArrayEquals("Rule contains one selector p::after", sel4.toArray(), rule4.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule4.size());
+    }
+    
+    @Test
+    public void nonlegacyPseudoElementSupport() throws CSSException, IOException {
+        StyleSheet style = CSSFactory.parseString(TEST_PSEUDO_2, null);
+        assertEquals("There are 4 rules", 4, style.size());
+        
+        List<CombinedSelector> sel1 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-line", null, true));
+        List<CombinedSelector> sel2 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-letter", null, true));
+        List<CombinedSelector> sel3 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("before", null, true));
+        List<CombinedSelector> sel4 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("after", null, true));
+
+        RuleSet rule1 = (RuleSet) style.get(0);
+        assertArrayEquals("Rule contains one selector p::first-line", sel1.toArray(), rule1.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule1.size());
+        
+        RuleSet rule2 = (RuleSet) style.get(1);
+        assertArrayEquals("Rule contains one selector p::first-letter", sel2.toArray(), rule2.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule2.size());
+        
+        RuleSet rule3 = (RuleSet) style.get(2);
+        assertArrayEquals("Rule contains one selector p::before", sel3.toArray(), rule3.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule3.size());
+        
+        RuleSet rule4 = (RuleSet) style.get(3);
+        assertArrayEquals("Rule contains one selector p::after", sel4.toArray(), rule4.getSelectors());
+        assertEquals("Rule contains one declaration", 1, rule4.size());
+    }
+    
     // Test for issue #83
     private static final String TEST_RANGE = 
             "input[type=range]::-webkit-slider-runnable-track { width: 1em; }\n" +
@@ -178,7 +243,6 @@ public class PseudoClassTest {
     
     @Test
     public void rangeInputPseudoElements() throws CSSException, IOException {
-        
         StyleSheet style = CSSFactory.parseString(TEST_RANGE, null);
         assertEquals("There are 6 rules", 6, style.size());
         

--- a/src/test/java/test/PseudoClassTest.java
+++ b/src/test/java/test/PseudoClassTest.java
@@ -3,7 +3,6 @@ package test;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,8 +24,8 @@ import cz.vutbr.web.css.NodeData;
 import cz.vutbr.web.css.RuleFactory;
 import cz.vutbr.web.css.RuleSet;
 import cz.vutbr.web.css.Selector;
+import cz.vutbr.web.css.Selector.PseudoClassType;
 import cz.vutbr.web.css.StyleSheet;
-import cz.vutbr.web.css.Selector.PseudoDeclaration;
 import cz.vutbr.web.css.TermColor;
 import cz.vutbr.web.css.TermFactory;
 import cz.vutbr.web.csskit.MatchConditionOnElements;
@@ -54,11 +53,11 @@ public class PseudoClassTest {
         Document doc = ds.parse();
         ElementMap elements = new ElementMap(doc);
         
-        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoDeclaration.LINK);
-        cond.addMatch(elements.getElementById("l2"), PseudoDeclaration.HOVER);
-        cond.addMatch(elements.getElementById("l3"), PseudoDeclaration.VISITED);
-        cond.addMatch(elements.getElementById("l3"), PseudoDeclaration.HOVER);
-        cond.removeMatch(elements.getElementById("l3"), PseudoDeclaration.HOVER);
+        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoClassType.LINK);
+        cond.addMatch(elements.getElementById("l2"), PseudoClassType.HOVER);
+        cond.addMatch(elements.getElementById("l3"), PseudoClassType.VISITED);
+        cond.addMatch(elements.getElementById("l3"), PseudoClassType.HOVER);
+        cond.removeMatch(elements.getElementById("l3"), PseudoClassType.HOVER);
         CSSFactory.registerDefaultMatchCondition(cond);
         
         StyleMap decl = CSSFactory.assignDOM(doc, null, createBaseFromFilename("data/simple/pseudo.html"),"screen", true);
@@ -79,9 +78,9 @@ public class PseudoClassTest {
         Document doc = ds.parse();
         ElementMap elements = new ElementMap(doc);
         
-        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoDeclaration.LINK);
-        cond.addMatch(elements.getElementById("l2"), PseudoDeclaration.HOVER);
-        cond.addMatch(elements.getElementById("l3"), PseudoDeclaration.VISITED);
+        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoClassType.LINK);
+        cond.addMatch(elements.getElementById("l2"), PseudoClassType.HOVER);
+        cond.addMatch(elements.getElementById("l3"), PseudoClassType.VISITED);
         CSSFactory.registerDefaultMatchCondition(cond);
         
         StyleSheet style = CSSFactory.getUsedStyles(doc, null, createBaseFromFilename("data/simple/selectors.html"),"screen");
@@ -103,11 +102,11 @@ public class PseudoClassTest {
         Document doc = ds.parse();
         ElementMap elements = new ElementMap(doc);
 
-        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoDeclaration.LINK);
-        cond.addMatch(elements.getElementById("l2"), PseudoDeclaration.HOVER);
-        cond.addMatch(elements.getElementById("l3"), PseudoDeclaration.VISITED);
-        cond.addMatch(elements.getElementById("l3"), PseudoDeclaration.HOVER);
-        cond.removeMatch(elements.getElementById("l3"), PseudoDeclaration.HOVER);
+        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoClassType.LINK);
+        cond.addMatch(elements.getElementById("l2"), PseudoClassType.HOVER);
+        cond.addMatch(elements.getElementById("l3"), PseudoClassType.VISITED);
+        cond.addMatch(elements.getElementById("l3"), PseudoClassType.HOVER);
+        cond.removeMatch(elements.getElementById("l3"), PseudoClassType.HOVER);
 
         StyleMap decl = CSSFactory.assignDOM(doc, null, createBaseFromFilename("data/simple/pseudo.html"),"screen", true, cond);
 
@@ -127,9 +126,9 @@ public class PseudoClassTest {
         Document doc = ds.parse();
         ElementMap elements = new ElementMap(doc);
 
-        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoDeclaration.LINK);
-        cond.addMatch(elements.getElementById("l2"), PseudoDeclaration.HOVER);
-        cond.addMatch(elements.getElementById("l3"), PseudoDeclaration.VISITED);
+        MatchConditionOnElements cond = new MatchConditionOnElements("a", PseudoClassType.LINK);
+        cond.addMatch(elements.getElementById("l2"), PseudoClassType.HOVER);
+        cond.addMatch(elements.getElementById("l3"), PseudoClassType.VISITED);
 
         StyleSheet style = CSSFactory.getUsedStyles(doc, null, createBaseFromFilename("data/simple/selectors.html"),"screen");
         DirectAnalyzer da = new DirectAnalyzer(style);
@@ -175,10 +174,10 @@ public class PseudoClassTest {
         StyleSheet style = CSSFactory.parseString(TEST_PSEUDO_1, null);
         assertEquals("There are 4 rules", 4, style.size());
         
-        List<CombinedSelector> sel1 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-line", null, true));
-        List<CombinedSelector> sel2 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-letter", null, true));
-        List<CombinedSelector> sel3 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("before", null, true));
-        List<CombinedSelector> sel4 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("after", null, true));
+        List<CombinedSelector> sel1 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("first-line"));
+        List<CombinedSelector> sel2 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("first-letter"));
+        List<CombinedSelector> sel3 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("before"));
+        List<CombinedSelector> sel4 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("after"));
 
         RuleSet rule1 = (RuleSet) style.get(0);
         assertArrayEquals("Rule contains one selector p::first-line", sel1.toArray(), rule1.getSelectors());
@@ -202,10 +201,10 @@ public class PseudoClassTest {
         StyleSheet style = CSSFactory.parseString(TEST_PSEUDO_2, null);
         assertEquals("There are 4 rules", 4, style.size());
         
-        List<CombinedSelector> sel1 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-line", null, true));
-        List<CombinedSelector> sel2 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("first-letter", null, true));
-        List<CombinedSelector> sel3 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("before", null, true));
-        List<CombinedSelector> sel4 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoPage("after", null, true));
+        List<CombinedSelector> sel1 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("first-line"));
+        List<CombinedSelector> sel2 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("first-letter"));
+        List<CombinedSelector> sel3 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("before"));
+        List<CombinedSelector> sel4 = SelectorsUtil.appendSimpleSelector(null, "p", null, rf.createPseudoElement("after"));
 
         RuleSet rule1 = (RuleSet) style.get(0);
         assertArrayEquals("Rule contains one selector p::first-line", sel1.toArray(), rule1.getSelectors());
@@ -251,11 +250,47 @@ public class PseudoClassTest {
                 "input", 
                 null, 
                 rf.createAttribute("range", false, Selector.Operator.EQUALS, "type"), 
-                rf.createPseudoPage(TEST_RANGE_ELEMENTS[i], null, true));
+                rf.createPseudoElement(TEST_RANGE_ELEMENTS[i]));
 
             RuleSet rule = (RuleSet) style.get(i);
             assertArrayEquals("Rule contains one selector input[type=range]::" + TEST_RANGE_ELEMENTS[i], cslist.toArray(), rule.getSelectors());
             assertEquals("Rule contains one declaration", 1, rule.size());
+        }
+    }
+    
+    @Test
+    public void childPseudoClassesTest() throws SAXException, IOException {
+        DOMSource ds = new DOMSource(getClass().getResourceAsStream("/simple/child-pseudo.html"));
+        Document doc = ds.parse();
+        ElementMap elements = new ElementMap(doc);
+
+        StyleSheet style = CSSFactory.getUsedStyles(doc, null, null, "screen");
+        DirectAnalyzer da = new DirectAnalyzer(style);
+
+        TermColor[] expected = new TermColor[] {
+            tf.createColor("#F0F"),
+            tf.createColor("#00F"),
+            tf.createColor("#00F"),
+            tf.createColor("#0F0"),
+            tf.createColor("#F00"),
+            tf.createColor("#FFF"),
+            tf.createColor("#FF0"),
+            tf.createColor("#FFF"),
+            tf.createColor("#000"),
+            tf.createColor("#0F0"),
+            tf.createColor("#000"),
+            tf.createColor("#FFF"),
+            tf.createColor("#0F0"),
+            tf.createColor("#FFF"),
+            tf.createColor("#F00"),
+            tf.createColor("#0F0"),
+            tf.createColor("#000"),
+            tf.createColor("#0FF")
+        };
+        
+        for (int id = 1; id <= 18; id++) {
+            NodeData nodeData = getStyleById(elements, da, "list-" + id);
+            assertThat(nodeData.getValue(TermColor.class, "color"), is(expected[id - 1]));
         }
     }
     

--- a/src/test/java/test/SelectorTest.java
+++ b/src/test/java/test/SelectorTest.java
@@ -295,8 +295,7 @@ public class SelectorTest {
 		RuleSet rule = (RuleSet) ss.get(0);
 
 		List<CombinedSelector> cslist = SelectorsUtil.appendCS(null);
-		SelectorsUtil.appendSimpleSelector(cslist, null, null, rf
-				.createPseudoPage("hover", null, false));
+		SelectorsUtil.appendSimpleSelector(cslist, null, null, rf.createPseudoClass("hover"));
 
 		assertArrayEquals("Rule contains one pseudoselector :hover", cslist.toArray(), rule
 				.getSelectors());
@@ -316,8 +315,7 @@ public class SelectorTest {
 		RuleSet rule = (RuleSet) ss.get(0);
 
 		List<CombinedSelector> cslist = SelectorsUtil.appendCS(null);
-		SelectorsUtil.appendSimpleSelector(cslist, null, null, rf
-				.createPseudoPage("fr", "lang", false));
+		SelectorsUtil.appendSimpleSelector(cslist, null, null, rf.createPseudoClass("lang", "fr"));
 		SelectorsUtil.appendChild(cslist, "Q");
 
 		assertArrayEquals("Rule contains one combined pseudoselector :lang(fr)>Q",
@@ -340,8 +338,9 @@ public class SelectorTest {
 
 		// test first rule
 		List<CombinedSelector> cslist = SelectorsUtil.appendCS(null);
-		SelectorsUtil.appendSimpleSelector(cslist, "P", null, rf
-				.createClass("special"), rf.createPseudoPage("before", null, true));
+		SelectorsUtil.appendSimpleSelector(cslist, "P", null, 
+                rf.createClass("special"), 
+                rf.createPseudoElement("before"));
 
 		assertArrayEquals("Rule 1 contains one combined selector P.special:before",
 				cslist.toArray(), ((RuleSet) ss.get(0)).getSelectors());
@@ -354,9 +353,9 @@ public class SelectorTest {
 
 		// test second rule
 		cslist = SelectorsUtil.appendCS(null);
-		SelectorsUtil.appendSimpleSelector(cslist, "P", null, rf
-				.createClass("special"), rf.createPseudoPage("first-letter",
-				null, true));
+		SelectorsUtil.appendSimpleSelector(cslist, "P", null, 
+                rf.createClass("special"), 
+                rf.createPseudoElement("first-letter"));
 
 		assertArrayEquals(
 				"Rule 2 contains one combined selector P.special:first-letter",

--- a/src/test/resources/simple/child-pseudo.html
+++ b/src/test/resources/simple/child-pseudo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Child-selector test</title>
+<style type="text/css">
+    li:nth-child(odd) { color: #000; } /* 1, 3, 5, etc. */
+    li:nth-child(even) { color: #FFF; } /* 2, 4, 6, etc. */
+    li:nth-child(5n) { color: #F00; } /* 5, 10, 15, etc. */
+    li:nth-child(3n+4) { color: #0F0; } /* 4, 7, 10, 13, etc. */
+    li:nth-child(-n+3) { color: #00F; } /* First 3 */
+    li:nth-child(7) { color: #FF0; } /* 7 */
+    li:first-child { color: #F0F; }
+    li:last-child { color: #0FF; }
+</style>
+</head>
+<body id="body">
+<h1>List</h1>
+<ul>
+    <li id="list-1">Matches odd, -n+3, first-child
+    <li id="list-2">Matches even, -n+3
+    <li id="list-3">Matches odd, -n+3
+    <li id="list-4">Matches even, 3n+4
+    <li id="list-5">Matches odd, 5n, 
+    <li id="list-6">Matches even, 
+    <li id="list-7">Matches odd, 3n+4, 7
+    <li id="list-8">Matches even, 
+    <li id="list-9">Matches odd, 
+    <li id="list-10">Matches even, 5n, 3n+4 
+    <li id="list-11">Matches odd, 
+    <li id="list-12">Matches even, 
+    <li id="list-13">Matches odd, 3n+4
+    <li id="list-14">Matches even, 
+    <li id="list-15">Matches odd, 5n, 
+    <li id="list-16">Matches even, 3n+4
+    <li id="list-17">Matches odd, 
+    <li id="list-18">Matches even, last-child
+</ul>
+</body>
+</html>


### PR DESCRIPTION
The third change discussed in [this comment](https://github.com/radkovo/jStyleParser/issues/83#issuecomment-373970856): splitting `PseudoPage`, which was used for all pseudo-classes and -elements, into dedicated classes for each use. I settled on three: 

* `PseudoPage`, for the pseudo-classes that modify `@page` rules,
* `PseudoClass`, for all other pseudo-classes, and
* `PseudoElement`, for pseudo-elements.

This also meant splitting `PseudoDeclaration` into three: `PseudoPageType`, `PseudoClassType`, and `PseudoElementType`, and picking the right type for each use. As far as I can tell, each use of `PseudoDeclaration` referred to exactly one of the new types, meaning the references are more specific now.

I'm not sure if I implemented the `matches` methods correctly (I left some `TODO` comments in the code there), but all the tests pass.