### PR TITLE
wrapped debug statements in cz.vutbr.web.csskit.antlr4 package

### DIFF
--- a/src/main/java/cz/vutbr/web/csskit/antlr4/CSSTokenRecovery.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/CSSTokenRecovery.java
@@ -214,7 +214,9 @@ public class CSSTokenRecovery {
             t.setText("]");
         }
 
-        log.debug("Recovering from EOF by {}", t.getText());
+        if (log.isDebugEnabled()) {
+            log.debug("Recovering from EOF by {}", t.getText());
+        }
         return t;
     }
 
@@ -224,8 +226,10 @@ public class CSSTokenRecovery {
      */
     private void consumeUntilBalanced(IntervalSet follow) {
 
-        log.debug("Lexer entered consumeUntilBalanced with {} and follow {}",
+        if (log.isDebugEnabled()) {
+            log.debug("Lexer entered consumeUntilBalanced with {} and follow {}",
                 ls, follow);
+        }
 
         int c;
         do {

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/SimplePreparator.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/SimplePreparator.java
@@ -43,8 +43,10 @@ public class SimplePreparator implements Preparator {
 		// check emptiness
 		if ((cslist == null || cslist.isEmpty())
 				|| (dlist == null || dlist.isEmpty())) {
-			log.debug("Empty RuleSet was ommited");
-			return null;
+                        if (log.isDebugEnabled()) {
+                            log.debug("Empty RuleSet was ommited");
+                        }                    
+                        return null;
 		}
 
 		// create rule set
@@ -57,7 +59,9 @@ public class SimplePreparator implements Preparator {
 		if (wrap) {
 			// swap numbers, so RuleMedia is created before RuleSet
 			RuleMedia rm = rf.createMedia();
-			log.debug("Wrapping RuleSet {} into RuleMedia: {}", rs, media);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Wrapping RuleSet {} into RuleMedia: {}", rs, media);
+                        }
 
 			rm.unlock();
 			rm.add(rs);
@@ -74,8 +78,10 @@ public class SimplePreparator implements Preparator {
 	public RuleBlock<?> prepareRuleMedia(List<RuleSet> rules, List<MediaQuery> media) {
 
 		if (rules == null || rules.isEmpty()) {
-			log.debug("Empty RuleMedia was ommited");
-			return null;
+                        if (log.isDebugEnabled()) {
+                            log.debug("Empty RuleMedia was ommited");
+                        }
+                        return null;
 		}
 
 		// create media at position of mark
@@ -94,8 +100,10 @@ public class SimplePreparator implements Preparator {
 
 	    if ((declarations == null || declarations.isEmpty()) &&
 	         (marginRules == null || marginRules.isEmpty())) {
-			log.debug("Empty RulePage was ommited");
-			return null;
+                        if (log.isDebugEnabled()) {
+                            log.debug("Empty RulePage was ommited");
+                        }
+                        return null;
 		}
 
 		RulePage rp = rf.createPage();
@@ -117,7 +125,9 @@ public class SimplePreparator implements Preparator {
 
         if ((decl == null || decl.isEmpty()))
         {
-            log.debug("Empty RuleMargin was ommited");
+            if (log.isDebugEnabled()) {
+                log.debug("Empty RuleMargin was ommited");
+            }
             return null;
         }
 
@@ -132,7 +142,9 @@ public class SimplePreparator implements Preparator {
     public RuleBlock<?> prepareRuleViewport(List<Declaration> decl) {
 
         if (decl == null || decl.isEmpty()) {
-            log.debug("Empty Viewport was ommited");
+            if (log.isDebugEnabled()) {
+                log.debug("Empty Viewport was ommited");
+            }
             return null;
         }
 
@@ -146,7 +158,9 @@ public class SimplePreparator implements Preparator {
     public RuleBlock<?> prepareRuleFontFace(List<Declaration> decl) {
 
         if (decl == null || decl.isEmpty()) {
-            log.debug("Empty RuleFontFace was ommited");
+            if (log.isDebugEnabled()) {
+                log.debug("Empty RuleFontFace was ommited");
+            }
             return null;
         }
 
@@ -162,8 +176,10 @@ public class SimplePreparator implements Preparator {
 			List<Selector.SelectorPart> pseudos) {
 
 		if(dlist==null || dlist.isEmpty()) {
-			log.debug("Empty RuleSet (inline) was ommited");
-			return null;
+                        if (log.isDebugEnabled()) {
+                            log.debug("Empty RuleSet (inline) was ommited");
+                        }
+                        return null;
 		}
 		
 		// create selector with element
@@ -186,11 +202,15 @@ public class SimplePreparator implements Preparator {
     @Override
     public RuleBlock<?> prepareRuleKeyframes(List<KeyframeBlock> rules, String name) {
         if (rules == null || rules.isEmpty()) {
-            log.debug("Empty RuleKeyframes was ommited");
+            if (log.isDebugEnabled()) {
+                log.debug("Empty RuleKeyframes was ommited");
+            }
             return null;
         }
         if (name == null || name.isEmpty()) {
-            log.debug("RuleKeyframes with no name was ommited");
+            if (log.isDebugEnabled()) {
+                log.debug("RuleKeyframes with no name was ommited");
+            }
             return null;
         }
 


### PR DESCRIPTION
We encountered an error in production caused by a syntax error in a template (missing a ]).

The stack-trace:
`Caused by: java.lang.NullPointerException at cz.vutbr.web.csskit.antlr4.CSSTokenRecovery.generateEOFRecover(CSSTokenRecovery.java:212)
         at cz.vutbr.web.csskit.antlr4.CSSTokenRecovery.nextToken(CSSTokenRecovery.java:174)
         at cz.vutbr.web.csskit.antlr4.CSSLexer.nextToken(CSSLexer.java:172)
         at org.antlr.v4.runtime.BufferedTokenStream.fetch(BufferedTokenStream.java:185)
         at org.antlr.v4.runtime.BufferedTokenStream.sync(BufferedTokenStream.java:168)
         at org.antlr.v4.runtime.BufferedTokenStream.consume(BufferedTokenStream.java:152)
         at org.antlr.v4.runtime.Parser.consume(Parser.java:591)
         at org.antlr.v4.runtime.Parser.match(Parser.java:224)
         at cz.vutbr.web.csskit.antlr4.CSSParser.atstatement(CSSParser.java:790)
         at cz.vutbr.web.csskit.antlr4.CSSParser.statement(CSSParser.java:495)
         at cz.vutbr.web.csskit.antlr4.CSSParser.stylesheet(CSSParser.java:388)
         at cz.vutbr.web.csskit.antlr4.CSSParserFactory.parse(CSSParserFactory.java:205)
         at cz.vutbr.web.csskit.antlr4.CSSParserFactory.parseAndImport(CSSParserFactory.java:147)
         at cz.vutbr.web.csskit.antlr4.CSSParserFactory.parse(CSSParserFactory.java:72)
         at cz.vutbr.web.csskit.antlr4.CSSParserFactory.parse(CSSParserFactory.java:93)
         at cz.vutbr.web.css.CSSFactory.parseString(CSSFactory.java:546)
         at cz.vutbr.web.css.CSSFactory.parseString(CSSFactory.java:521`

Version 3.3 (we use 3.2) should manage the 'missing closing ]' case (CSSTokenRecovery#generateEOFRecover), but i still took the chance to wrap 'log.debug' statements in the cz.vutbr.web.csskit.antlr4 package.