### PR TITLE
Fix NoSuchElementException when to many closing parenthesis are used …

### DIFF
--- a/src/main/java/cz/vutbr/web/csskit/CalcArgs.java
+++ b/src/main/java/cz/vutbr/web/csskit/CalcArgs.java
@@ -91,11 +91,14 @@ public class CalcArgs extends ArrayList<Term<?>> {
                     stack.push(op);
                     unary = true;
                 } else if (op.getValue() == ')') {
-                    TermOperator top = stack.pop();
-                    while (top != null && top.getValue() != '(') {
-                        add(top);
-                        top = stack.pop();
+                    if (!stack.isEmpty()) {
+                        TermOperator top = stack.pop();
+                        while (top != null && top.getValue() != '(' && !stack.isEmpty()) {
+                            add(top);
+                            top = stack.pop();
+                        }
                     }
+
                     unary = false;
                 } else {
                     valid = false;

--- a/src/test/java/test/GrammarRecovery3Test.java
+++ b/src/test/java/test/GrammarRecovery3Test.java
@@ -18,6 +18,8 @@ public class GrammarRecovery3Test {
     public static final TermFactory tf = CSSFactory.getTermFactory();
 
     public static final String TEST_EXPR1 = "p { top:20px;top:expression(body.scrollTop + 50 + \"px\"); position:absolute;}";
+    public static final String TEST_EXPR2 = "p { top:calc(10px+10px)); position:absolute;}";
+    public static final String TEST_EXPR3 = "p { top:calc(10px+10px))); position:absolute;}";
 
     @BeforeClass
     public static void init() {
@@ -30,6 +32,21 @@ public class GrammarRecovery3Test {
         assertEquals("There are only two declarations", 2, ss.get(0).size());
         assertEquals("First property is top", "top", ((Declaration) ss.get(0).get(0)).getProperty());
         assertEquals("Top value is 20px", tf.createLength((float) 20.0, TermNumeric.Unit.px), ((Declaration) ss.get(0).get(0)).get(0));
+        assertEquals("Second property is position", "position", ((Declaration) ss.get(0).get(1)).getProperty());
+        assertEquals("Position is absolute", "absolute", ((Declaration) ss.get(0).get(1)).get(0).getValue());
+    }
+
+    @Test
+    public void calcParenthesisRecovery() throws IOException, CSSException {
+        StyleSheet ss = CSSFactory.parseString(TEST_EXPR2, null);
+        assertEquals("There are only two declarations", 2, ss.get(0).size());
+        assertEquals("First property is top", "top", ((Declaration) ss.get(0).get(0)).getProperty());
+        assertEquals("Second property is position", "position", ((Declaration) ss.get(0).get(1)).getProperty());
+        assertEquals("Position is absolute", "absolute", ((Declaration) ss.get(0).get(1)).get(0).getValue());
+
+        ss = CSSFactory.parseString(TEST_EXPR3, null);
+        assertEquals("There are only two declarations", 2, ss.get(0).size());
+        assertEquals("First property is top", "top", ((Declaration) ss.get(0).get(0)).getProperty());
         assertEquals("Second property is position", "position", ((Declaration) ss.get(0).get(1)).getProperty());
         assertEquals("Position is absolute", "absolute", ((Declaration) ss.get(0).get(1)).get(0).getValue());
     }


### PR DESCRIPTION
Css like `p { top:calc(10px+10px));` crashes the parser with a NoSuchElementException. 
```
java.util.NoSuchElementException
	at java.base/java.util.ArrayDeque.removeFirst(ArrayDeque.java:362)
	at java.base/java.util.ArrayDeque.pop(ArrayDeque.java:593)
	at cz.vutbr.web.csskit.CalcArgs.scanArguments(CalcArgs.java:97)
	at cz.vutbr.web.csskit.CalcArgs.<init>(CalcArgs.java:45)
```

With this fix the parser will recover and continue.