### PR TITLE
Support JavaFX specific pseudo-classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.sf.cssbox</groupId>
     <artifactId>jstyleparser</artifactId>
-    <version>4.0.2-SNAPSHOT</version>
+    <version>4.0.2</version>
     <name>jStyleParser</name>
     <description>jStyleParser is a CSS parser written in Java. It has its own application interface that is designed to allow an efficient CSS processing in Java and mapping the values to the Java data types. It parses CSS 2.1 style sheets into structures that can be efficiently assigned to DOM elements. It is intended be the primary CSS parser for the CSSBox library. While handling errors, it is user agent conforming according to the CSS specification.</description>
     <url>http://cssbox.sourceforge.net/jstyleparser</url>

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -122,6 +122,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         INDETERMINATE("indeterminate"),
         IN_RANGE("in-range"),
         INVALID("invalid"),
+        JAVAFX(null),
         LANG("lang"),
         LAST_CHILD("last-child"),
         LAST_OF_TYPE("last-of-type"),
@@ -171,10 +172,87 @@ public interface Selector extends Rule<Selector.SelectorPart> {
                     }
                 }
             }
+
+            PseudoClassType type = lookup.get(name.toLowerCase());
+            if (type == null) {
+                if (JFXPseudoClassType.forName(name) != null) {
+                    return JAVAFX;
+                }
+            }
+            return type;
+        }
+    }
+
+    /**
+     * JavaFX pseudo-class type
+     */
+    public enum JFXPseudoClassType {
+        ARMED("armed"),
+        BOTTOM("bottom"),
+        CANCEL("cancel"),
+        CELL_SELECTION("cell-selection"),
+        COLLAPSED("collapsed"),
+        DEFAULT("default"),
+        DETERMINATE("determinate"),
+        DISABLED("disabled"),
+        EDITABLE("editable"),
+        EMPTY("empty"),
+        EVEN("even"),
+        EXPANDED("expanded"),
+        FILLED("filled"),
+        FIRST_CHILD("first-child"),
+        FIT_TO_HEIGHT("fitToHeight"),
+        FIT_TO_WIDTH("fitToWidth"),
+        FOCUS_VISIBLE("focus-visible"),
+        FOCUS_WITHIN("focus-within"),
+        FOCUSED("focused"),
+        HORIZONTAL("horizontal"),
+        HOVER("hover"),
+        INDETERMINATE("indeterminate"),
+        LAST_CHILD("last-child"),
+        LAST_VISIBLE("last-visible"),
+        LEFT("left"),
+        NTH_CHILD_EVEN("nth-childeven"),
+        NTH_CHILD_ODD("nth-childodd"),
+        ODD("odd"),
+        ONLY_CHILD("only-child"),
+        OPEN_VERTICALLY("openvertically"),
+        PANNABLE("pannable"),
+        PRESSED("pressed"),
+        READONLY("readonly"),
+        RIGHT("right"),
+        ROOT("root"),
+        ROW_SELECTION("row-selection"),
+        SELECTED("selected"),
+        SHOW_MNEMONIC("show-mnemonic"),
+        SHOWING("showing"),
+        TOP("top"),
+        VERTICAL("vertical"),
+        VISITED("visited");
+
+        private static final Map<String, JFXPseudoClassType> lookup = new ConcurrentHashMap<>();
+        private final String name;
+
+        JFXPseudoClassType(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public static JFXPseudoClassType forName(String name) {
+            if (lookup.isEmpty()) {
+                for (JFXPseudoClassType type : values()) {
+                    if (type.getName() != null) {
+                        lookup.put(type.getName(), type);
+                    }
+                }
+            }
             return lookup.get(name.toLowerCase());
         }
     }
-    
+
     /**
      * A pseudo-element
      */
@@ -359,6 +437,7 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         public String getName();
         public String getFunctionValue();
         public PseudoClassType getType();
+        public JFXPseudoClassType getJfxType();
         public Selector getNestedSelector();
     }
     

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -435,12 +435,18 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         private final String name;
         private final String functionValue;
         private final PseudoClassType type;
+        private final JFXPseudoClassType jfxType;
         private Selector nestedSelector; // for :not(sel)
     	private int[] elementIndex; // decoded element index for nth-XXXX properties -- values a and b in the an+b specification
         
         private PseudoClassImpl(String name, String functionValue, Selector nestedSelector) {
             this.name = name;
             type = PseudoClassType.forName(name);
+            if (type == PseudoClassType.JAVAFX) {
+                jfxType = JFXPseudoClassType.forName(name);
+            } else {
+                jfxType = null;
+            }
             this.functionValue = functionValue;
             this.nestedSelector = nestedSelector;
             
@@ -491,6 +497,11 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         @Override
         public PseudoClassType getType() {
             return type;
+        }
+
+        @Override
+        public JFXPseudoClassType getJfxType() {
+            return jfxType;
         }
 
         @Override


### PR DESCRIPTION
A new JFXPseudoClassType enum has been added to source file Selector.java.
It is based on the PseudoClassType but represent JavaFX pseudo class, redundancies have not been removed for completude.
A new attribute JAVAFX has been added to PseudoClassType, giving a hook to the specific JavaFX pseudo-class (see diff).