### PR TITLE
Add support for pseudo classes :is(), :where() and support :not() with a selector list.

### DIFF
--- a/src/main/antlr4/cz/vutbr/web/csskit/antlr4/CSSParser.g4
+++ b/src/main/antlr4/cz/vutbr/web/csskit/antlr4/CSSParser.g4
@@ -471,7 +471,7 @@ attribute
      }
 
 pseudo
-    : COLON COLON? (MINUS? IDENT | FUNCTION S* (MINUS? IDENT | MINUS? NUMBER | MINUS? INDEX | selector) S* RPAREN)
+    : COLON COLON? (MINUS? IDENT | FUNCTION S* (MINUS? IDENT | MINUS? NUMBER | MINUS? INDEX | (selector (COMMA S* selector)*)) S* RPAREN)
     ;
     catch [RecognitionException re] {
       log.error("PARSING pseudo ERROR | inserting INVALID_SELPART");

--- a/src/main/java/cz/vutbr/web/css/RuleFactory.java
+++ b/src/main/java/cz/vutbr/web/css/RuleFactory.java
@@ -4,6 +4,8 @@ import org.w3c.dom.Element;
 
 import cz.vutbr.web.css.Selector.Operator;
 
+import java.util.List;
+
 /**
  * Creates rules, declarations and selectors,
  * that is the most of CSS grammar elements
@@ -179,7 +181,7 @@ public interface RuleFactory {
      * @param nestedSelector Selector in its function argument
 	 * @return New CSS pseudo-element
 	 */
-	Selector.PseudoElement createPseudoElement(String name, Selector nestedSelector);
+	Selector.PseudoElement createPseudoElement(String name, List<Selector> nestedSelector);
     
 	/**
 	 * Creates CSS selector part, pseudo-class
@@ -202,7 +204,7 @@ public interface RuleFactory {
      * @param nestedSelector Selector in its function argument
 	 * @return New CSS pseudo-class
 	 */
-	Selector.PseudoClass createPseudoClass(String name, Selector nestedSelector);
+	Selector.PseudoClass createPseudoClass(String name, List<Selector> nestedSelector);
 
 	/**
 	 * Creates CSS author style sheet

--- a/src/main/java/cz/vutbr/web/css/Selector.java
+++ b/src/main/java/cz/vutbr/web/css/Selector.java
@@ -1,5 +1,6 @@
 package cz.vutbr.web.css;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.w3c.dom.Element;
@@ -118,6 +119,8 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         FOCUS("focus"),
         FOCUS_WITHIN("focus-within"),
         HAS("has"),
+        IS("is"),
+        WHERE("where"),
         HOVER("hover"),
         INDETERMINATE("indeterminate"),
         IN_RANGE("in-range"),
@@ -359,13 +362,13 @@ public interface Selector extends Rule<Selector.SelectorPart> {
         public String getName();
         public String getFunctionValue();
         public PseudoClassType getType();
-        public Selector getNestedSelector();
+        public List<Selector> getNestedSelectors();
     }
     
     public interface PseudoElement extends SelectorPart {
         public String getName();
         public String getFunctionValue();
         public PseudoElementType getType();
-        public Selector getNestedSelector();
+        public List<Selector> getNestedSelectors();
     }
 }

--- a/src/main/java/cz/vutbr/web/csskit/RuleFactoryImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/RuleFactoryImpl.java
@@ -28,6 +28,8 @@ import cz.vutbr.web.css.Selector.ElementID;
 import cz.vutbr.web.css.Selector.ElementName;
 import cz.vutbr.web.css.Selector.Operator;
 
+import java.util.List;
+
 /**
  * @author kapy
  *
@@ -176,7 +178,7 @@ public class RuleFactoryImpl implements RuleFactory {
     }
     
     @Override
-    public Selector.PseudoElement createPseudoElement(String name, Selector nestedSelector) {
+    public Selector.PseudoElement createPseudoElement(String name, List<Selector> nestedSelector) {
         return new SelectorImpl.PseudoElementImpl(name, nestedSelector);
     }
     
@@ -191,7 +193,7 @@ public class RuleFactoryImpl implements RuleFactory {
     }
     
 	@Override
-    public Selector.PseudoClass createPseudoClass(String name, Selector nestedSelector) {
+    public Selector.PseudoClass createPseudoClass(String name, List<Selector> nestedSelector) {
         return new SelectorImpl.PseudoClassImpl(name, nestedSelector);
     }
     

--- a/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/SelectorImpl.java
@@ -2,7 +2,9 @@ package cz.vutbr.web.csskit;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import cz.vutbr.web.csskit.CombinedSelectorImpl.SpecificityImpl;
 import org.unbescape.css.CssEscape;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -435,23 +437,24 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         private final String name;
         private final String functionValue;
         private final PseudoClassType type;
-        private Selector nestedSelector; // for :not(sel)
+        private List<Selector> nestedSelectors; // for :not(sel)
     	private int[] elementIndex; // decoded element index for nth-XXXX properties -- values a and b in the an+b specification
         
-        private PseudoClassImpl(String name, String functionValue, Selector nestedSelector) {
+        private PseudoClassImpl(String name, String functionValue, List<Selector> nestedSelectors) {
             this.name = name;
             type = PseudoClassType.forName(name);
             this.functionValue = functionValue;
-            this.nestedSelector = nestedSelector;
+            this.nestedSelectors = nestedSelectors;
             
             // Type-specific initialization
             if (type != null) {
                 switch (type) {
                     case NOT:
-                        if (nestedSelector == null && functionValue != null) {
-                            nestedSelector = new SelectorImpl();
+                        if (nestedSelectors == null && functionValue != null) {
+                            SelectorImpl nestedSelector = new SelectorImpl();
                             nestedSelector.unlock();
                             nestedSelector.add(new ElementNameImpl(functionValue));
+                            this.nestedSelectors = List.of(nestedSelector);
                         }
                         break;
                     case NTH_CHILD:
@@ -474,7 +477,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             this(name, functionValue, null);
         }
         
-        protected PseudoClassImpl(String name, Selector nestedSelector) {
+        protected PseudoClassImpl(String name, List<Selector> nestedSelector) {
             this(name, null, nestedSelector);
         }
         
@@ -494,13 +497,35 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         }
 
         @Override
-        public Selector getNestedSelector() {
-            return nestedSelector;
+        public List<Selector> getNestedSelectors() {
+            return nestedSelectors;
         }
 
         @Override
         public void computeSpecificity(Specificity spec) {
-            spec.add(Level.C);
+            switch (type) {
+                case WHERE:
+                    // where has 0 specificity
+                    break;
+                case IS:
+                case NOT:
+                    if (nestedSelectors != null && !nestedSelectors.isEmpty()) {
+                        Specificity highestSpecificity = null;
+                        Selector selectorWithHighestSpecificity = null;
+                        for (Selector nestedSelector : nestedSelectors) {
+                            Specificity specificity = new SpecificityImpl();
+                            nestedSelector.computeSpecificity(specificity);
+                            if (highestSpecificity == null || specificity.compareTo(highestSpecificity) > 0) {
+                                selectorWithHighestSpecificity = nestedSelector;
+                                highestSpecificity = specificity;
+                            }
+                        }
+                        selectorWithHighestSpecificity.computeSpecificity(spec);
+                    }
+                    break;
+                default:
+                    spec.add(Level.C);
+            }
         }
         
         @Override
@@ -601,7 +626,25 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
                     }
                     return true;
                 case NOT:
-                    return nestedSelector != null && !nestedSelector.matches(e, matcher, cond);
+                    if (nestedSelectors != null) {
+                        for (Selector nestedSelector : nestedSelectors) {
+                            if (nestedSelector.matches(e, matcher, cond)) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                    return false;
+                case IS:
+                case WHERE:
+                    if (nestedSelectors != null) {
+                        for (Selector nestedSelector : nestedSelectors) {
+                            if (nestedSelector.matches(e, matcher, cond)) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
                 default:
                     // match all pseudo classes specified by an additional condition (usually used for using LINK pseudo class for links)
                     return cond.isSatisfied(e, this);
@@ -748,8 +791,8 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 			if(name!=null) 
 				sb.append(name);
             
-			if(nestedSelector != null)
-			    sb.append(OutputUtil.FUNCTION_OPENING).append(nestedSelector.toString()).append(OutputUtil.FUNCTION_CLOSING);
+			if(nestedSelectors != null)
+			    sb.append(OutputUtil.FUNCTION_OPENING).append(nestedSelectors.stream().map(Object::toString).collect(Collectors.joining(", "))).append(OutputUtil.FUNCTION_CLOSING);
 			else if(functionValue != null)
 			    sb.append(OutputUtil.FUNCTION_OPENING).append(functionValue).append(OutputUtil.FUNCTION_CLOSING);
 			
@@ -762,7 +805,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             hash = 43 * hash + Objects.hashCode(this.name);
             hash = 43 * hash + Objects.hashCode(this.functionValue);
             hash = 43 * hash + Objects.hashCode(this.type);
-            hash = 43 * hash + Objects.hashCode(this.nestedSelector);
+            hash = 43 * hash + Objects.hashCode(this.nestedSelectors);
             return hash;
         }
 
@@ -787,7 +830,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             if (!Objects.equals(this.functionValue, other.functionValue)) {
                 return false;
             }
-            if (!Objects.equals(this.nestedSelector, other.nestedSelector)) {
+            if (!Objects.equals(this.nestedSelectors, other.nestedSelectors)) {
                 return false;
             }
             return true;
@@ -799,21 +842,22 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         private final String name;
         private final String functionValue;
         private final PseudoElementType type;
-        private Selector nestedSelector; // for ::cue(sel)
+        private List<Selector> nestedSelectors; // for ::cue(sel)
         
-        private PseudoElementImpl(String name, String functionValue, Selector nestedSelector) {
+        private PseudoElementImpl(String name, String functionValue, List<Selector> nestedSelectors) {
             this.name = name;
             type = PseudoElementType.forName(name);
             this.functionValue = functionValue;
-            this.nestedSelector = nestedSelector;
+            this.nestedSelectors = nestedSelectors;
             
             // Type-specific initialization
             if (type != null) {
                 switch (type) {
                     case CUE:
-                        if (nestedSelector == null && functionValue != null) {
-                            nestedSelector = new SelectorImpl();
+                        if (nestedSelectors == null && functionValue != null) {
+                            SelectorImpl nestedSelector = new SelectorImpl();
                             nestedSelector.add(new ElementNameImpl(functionValue));
+                            this.nestedSelectors = List.of(nestedSelector);
                         }
                         break;
                     default:
@@ -830,7 +874,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             this(name, functionValue, null);
         }
         
-        protected PseudoElementImpl(String name, Selector nestedSelector) {
+        protected PseudoElementImpl(String name, List<Selector> nestedSelector) {
             this(name, null, nestedSelector);
         }
         
@@ -850,8 +894,8 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
         }
 
         @Override
-        public Selector getNestedSelector() {
-            return nestedSelector;
+        public List<Selector> getNestedSelectors() {
+            return nestedSelectors;
         }
 
         @Override
@@ -875,9 +919,9 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
 			
 			if(name!=null) 
 				sb.append(name);
-            
-			if(nestedSelector != null)
-			    sb.append(OutputUtil.FUNCTION_OPENING).append(nestedSelector.toString()).append(OutputUtil.FUNCTION_CLOSING);
+
+            if(nestedSelectors != null)
+                sb.append(OutputUtil.FUNCTION_OPENING).append(nestedSelectors.stream().map(Object::toString).collect(Collectors.joining(", "))).append(OutputUtil.FUNCTION_CLOSING);
 			else if(functionValue != null)
 			    sb.append(OutputUtil.FUNCTION_OPENING).append(functionValue).append(OutputUtil.FUNCTION_CLOSING);
 			
@@ -890,7 +934,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             hash = 53 * hash + Objects.hashCode(this.name);
             hash = 53 * hash + Objects.hashCode(this.functionValue);
             hash = 53 * hash + Objects.hashCode(this.type);
-            hash = 53 * hash + Objects.hashCode(this.nestedSelector);
+            hash = 53 * hash + Objects.hashCode(this.nestedSelectors);
             return hash;
         }
 
@@ -915,7 +959,7 @@ public class SelectorImpl extends AbstractRule<Selector.SelectorPart> implements
             if (!Objects.equals(this.functionValue, other.functionValue)) {
                 return false;
             }
-            if (!Objects.equals(this.nestedSelector, other.nestedSelector)) {
+            if (!Objects.equals(this.nestedSelectors, other.nestedSelectors)) {
                 return false;
             }
             return true;

--- a/src/main/java/cz/vutbr/web/csskit/antlr4/CSSParserVisitorImpl.java
+++ b/src/main/java/cz/vutbr/web/csskit/antlr4/CSSParserVisitorImpl.java
@@ -1613,9 +1613,12 @@ public class CSSParserVisitorImpl implements CSSParserVisitor<Object>, CSSParser
         if (ctx.FUNCTION() != null) {
             // function
             name = extractTextUnescaped(ctx.FUNCTION().getText());
-            if (ctx.selector() != null) {
-                Selector sel = visitSelector(ctx.selector());
-                pseudo = (isPseudoElem ? rf.createPseudoElement(name, sel) : rf.createPseudoClass(name, sel));
+            if (ctx.selector() != null && !ctx.selector().isEmpty()) {
+                List<Selector> selectors = new ArrayList<>(ctx.selector().size());
+                for (CSSParser.SelectorContext selectorContext : ctx.selector()) {
+                    selectors.add(visitSelector(selectorContext));
+                }
+                pseudo = (isPseudoElem ? rf.createPseudoElement(name, selectors) : rf.createPseudoClass(name, selectors));
             } else {
                 String value = (ctx.MINUS() == null ? "" : "-");
                 if (ctx.IDENT() != null) {

--- a/src/test/java/test/DOMAssignDirectTest.java
+++ b/src/test/java/test/DOMAssignDirectTest.java
@@ -1,5 +1,6 @@
 package test;
 
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
@@ -164,6 +165,29 @@ public class DOMAssignDirectTest {
         assertThat("Child combinator", i2.getValue(TermColor.class, "color"), is(tf.createColor(0,128,0)));
         assertThat("Adjacent sibling combinator", i3.getValue(TermColor.class, "color"), is(tf.createColor(0,128,0)));
         assertThat("Generic sibling combinator", i4.getValue(TermColor.class, "color"), is(tf.createColor(0,128,0)));
+    }
+
+    @Test
+    public void notIsWhere() throws SAXException, IOException {
+
+        DOMSource ds = new DOMSource(getClass().getResourceAsStream("/simple/selectors4.html"));
+        Document doc = ds.parse();
+        ElementMap elements = new ElementMap(doc);
+
+        StyleSheet style = CSSFactory.getUsedStyles(doc, null, getClass().getResource("/simple/selectors4.html"),"screen");
+        DirectAnalyzer da = new DirectAnalyzer(style);
+
+        NodeData i1 = getStyleById(elements, da, "i1");
+        NodeData i2 = getStyleById(elements, da, "i2");
+        NodeData i3 = getStyleById(elements, da, "i3");
+        NodeData i4 = getStyleById(elements, da, "i4");
+
+        assertThat("Not selector matches", i1.getValue(TermColor.class, "color"), is(tf.createColor(255,0,0)));
+        assertThat("Not selector does not match", i2.getValue(TermColor.class, "color"), is(tf.createColor(0,0,255)));
+        assertThat("is matches", i3.getValue(TermColor.class, "color"), is(tf.createColor(0,128,0)));
+        assertThat(":not(:is) matches", i1.getValue(TermColor.class, "background-color"), is(tf.createColor(170,170,170)));
+        assertThat(":not(:is) does not match", i3.getValue(TermColor.class, "background-color"), is(nullValue()));
+        assertThat("specificity", i4.getValue(TermColor.class, "color"), is(tf.createColor(255,0,0)));
     }
 
     @Test

--- a/src/test/java/test/PseudoSelectorTest.java
+++ b/src/test/java/test/PseudoSelectorTest.java
@@ -7,12 +7,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
+import cz.vutbr.web.css.*;
 import org.junit.Test;
-
-import cz.vutbr.web.css.CSSException;
-import cz.vutbr.web.css.CSSFactory;
-import cz.vutbr.web.css.StyleSheet;
-import cz.vutbr.web.css.TermFactory;
 
 /**
  * @author burgetr
@@ -29,6 +25,12 @@ public class PseudoSelectorTest
     public static final String TEST_HAS = 
         "td:has(.servNoPad) { padding:0px !important; }";
 
+    public static final String TEST_IS =
+            "td:is(.servNoPad) { padding:0px !important; }";
+
+    public static final String TEST_IS_MULTI =
+            "td:is(.servNoPad, a) { padding:0px !important; }";
+
 
     @Test 
     public void testHas() throws IOException, CSSException   {
@@ -36,6 +38,23 @@ public class PseudoSelectorTest
         StyleSheet ss = CSSFactory.parseString(TEST_HAS, null);
         
         assertEquals("One rule is set", 1, ss.size());
+    }
+
+    @Test
+    public void testIs() throws IOException, CSSException   {
+
+        StyleSheet ss = CSSFactory.parseString(TEST_IS, null);
+
+        assertEquals("One rule is set", 1, ss.size());
+    }
+
+    @Test
+    public void testIsMulti() throws IOException, CSSException   {
+
+        StyleSheet ss = CSSFactory.parseString(TEST_IS_MULTI, null);
+
+        assertEquals("One rule is set", 1, ss.size());
+        assertEquals("parsed rule", "td:is(.servNoPad, a)", ((RuleSet)ss.get(0)).getSelectors()[0].toString());
     }
     
     

--- a/src/test/resources/simple/selectors4.css
+++ b/src/test/resources/simple/selectors4.css
@@ -1,0 +1,27 @@
+p {
+	color: blue;
+}
+
+p:not(.notTooRed,.notRed) {
+	color: red;
+}
+
+p:is(.verygreen,.green) {
+	color: green;
+}
+
+p:not(:is(.verygreen,.green)) {
+	background-color: #aaa;
+}
+
+p.specificityTest {
+    color:#000;
+}
+
+p:is(.specificityTest) {
+    color: red;
+}
+
+p:where(.specificityTest) {
+    color: blue;
+}

--- a/src/test/resources/simple/selectors4.html
+++ b/src/test/resources/simple/selectors4.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+<title>Selector test</title>
+<link rel="stylesheet" type="text/css" href="selectors4.css">
+</head>
+<body id="body">
+<h1>List</h1>
+<div id="main">
+    <p id="i1">Item 1</p>
+    <p id="i2" class="notRed">Item 2</p>
+    <p id="i3" class="green">Item 3</p>
+    <p id="i4" class="specificityTest">Item 4</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This PR adds support for the pseudo classes :is(), :where() and extends support for :not() to allow a list of selectors.

I have also added simple test cases for these selectors and made sure the existing tests still pass.

Note: I had to change the interfaces PseudoClass, PseudoElement and RuleFactory to allow passing a list of nested selectors.